### PR TITLE
Add license text.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 David Hebbeker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 David Hebbeker
+Copyright (c) 2022 David Hebbeker & Marcel Walter
 and [contributors](https://github.com/dhebbeker/task-tracker/graphs/contributors "list of all contributors")
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 David Hebbeker
+and [contributors](https://github.com/dhebbeker/task-tracker/graphs/contributors "list of all contributors")
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I used GitHub's template to create the license file.
I added a line referring to the list of contributors. This attempts to give all contributors credit without the need to update the copyright notice each time a new contributor's contribution is added.