### PR TITLE
Remove declaration of transitive dependencies.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,8 +29,6 @@ build_src_filter = +<*> -<.git/> -<.svn/>
 ;general dependencies
 ; for version requirements see https://docs.platformio.org/en/stable/core/userguide/pkg/cmd_install.html#cmd-pkg-install-requirements
 lib_deps = 
-  adafruit/Adafruit BusIO@~1.11.6
-  adafruit/Adafruit GFX Library@~1.11.1
   adafruit/Adafruit SSD1306@~2.5.3
 
 ;general serial monitor baud rate

--- a/wokwi_files/libraries.txt
+++ b/wokwi_files/libraries.txt
@@ -1,5 +1,3 @@
 # Wokwi Library List
 # See https://docs.wokwi.com/guides/libraries
-Adafruit BusIO@1.11.6
-Adafruit GFX Library@1.11.1
 Adafruit SSD1306@2.5.3


### PR DESCRIPTION
Remove the specification of dependencies which are indirect only. Transitive dependencies will be automatically resolved. Specifying them directly is duplication.