### PR TITLE
Add configuration for Wokwi runs.

### DIFF
--- a/wokwi_files/wokwi.toml
+++ b/wokwi_files/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+elf = "../.pio/build/esp32dev/firmware.elf"
+firmware = "../.pio/build/esp32dev/firmware.bin"


### PR DESCRIPTION
This file allows to use the the [Wokwi for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode). Wokwi allows to simulate the project.

In contrast to the browser version of Wokwi this uses the current circuit diagram from the repository. Also the file has to be compiled locally. Thus one does not need to wait for a slot in their online compiler.