### PR TITLE
Use a library to control output shift register.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,7 @@ build_src_filter = +<*> -<.git/> -<.svn/>
 ; for version requirements see https://docs.platformio.org/en/stable/core/userguide/pkg/cmd_install.html#cmd-pkg-install-requirements
 lib_deps = 
   adafruit/Adafruit SSD1306@~2.5.3
+  simsso/ShiftRegister74HC595@^1.3.1
 
 ;general serial monitor baud rate
 monitor_speed = 115200

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,16 +8,10 @@
 #include <cmath>
 #include <cstdint>
 
-namespace OutputShiftRegister
-{
-using namespace board::osr;
-
 /**
  * Output shift registers with most significant bit first.
  */
-ShiftRegister74HC595<1U> outputShiftRegister(pin::data, pin::clock, pin::latch);
-
-} // namespace OutputShiftRegister
+ShiftRegister74HC595<1U> outputShiftRegister(board::osr::pin::data, board::osr::pin::clock, board::osr::pin::latch);
 
 namespace InputShiftRegister
 {
@@ -79,12 +73,12 @@ void loop()
     {
         constexpr std::uint16_t notes[] = {note::c4, note::g3, note::a3, note::b3, note::d1, note::e1, note::f1, note::g1};
         const std::uint8_t newRegisterValue = 1 << (8 - event);
-        OutputShiftRegister::outputShiftRegister.setAll(&newRegisterValue);
+        outputShiftRegister.setAll(&newRegisterValue);
         tone(board::buzzer::pin::on_off, notes[event - 1], 250);
     }
     else
     {
-        OutputShiftRegister::outputShiftRegister.setAllLow();
+        outputShiftRegister.setAllLow();
     }
     delay(100);
     testanimate(); // Animate bitmaps


### PR DESCRIPTION
This reduces the amount of code we have to maintain.