### PR TITLE
Add environment 'native' to be used for unit test on host system

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,8 @@ monitor_speed = 115200
 
 [env:native]
 platform = native
+lib_deps =
+    ArduinoFake
 
 ;-------------------------------------------------------
 ; ESP32 build environment                              |

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,8 @@ monitor_speed = 115200
 platform = native
 lib_deps =
     ArduinoFake
+build_flags =
+    -Wno-deprecated ; Workaround for https://github.com/FabioBatSilva/ArduinoFake/pull/41#issuecomment-1440550553
 
 ;-------------------------------------------------------
 ; ESP32 build environment                              |

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,9 @@ lib_deps =
 ;general serial monitor baud rate
 monitor_speed = 115200
 
+[env:native]
+platform = native
+
 ;-------------------------------------------------------
 ; ESP32 build environment                              |
 ;-------------------------------------------------------


### PR DESCRIPTION
In order to run unit tests on the host system, an environment with 'native' platform is required. For mocking the Arduino framework, ArduinoFake library shall be used. That library uses an STL feature which is depreciated in newer versions of the C++ Language Standard. Thus a warning is deactivated for that environment.

This pull request is a preparation for future uses of unit tests (already in progress).