### PR TITLE
Miscellaneous cleanup of `platformio.ini`

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,3 +17,4 @@ lib_deps =
 	adafruit/Adafruit SSD1306@~2.5.3
 	simsso/ShiftRegister74HC595@^1.3.1
 monitor_speed = 115200
+monitor_filters = esp32_exception_decoder

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,49 +1,28 @@
 ; PlatformIO Project Configuration File
 ;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-;-------------------------------------------------------
-; global PIO parameters                                |
-;-------------------------------------------------------
 [platformio]
-;default build enfironment for PIO project
 default_envs = esp32-s3-devkitc-1
-
-;Path to source files relative to PIO project
-; see https://docs.platformio.org/en/stable/projectconf/sections/platformio/options/directory/src_dir.html
 src_dir = src
-
-;switch "include" path to be src as well, as we decide to have headers and sources in same directories
-; this prevents the build environment from complaining the path not existing
 include_dir = src
+description = Task Tracker
 
-;-------------------------------------------------------
-; common parameters for all environments [env:...]     |
-;-------------------------------------------------------
 [env]
-;filter for source file directory when building
-; see https://docs.platformio.org/en/stable/projectconf/sections/env/options/build/build_src_filter.html
 build_src_filter = +<*> -<.git/> -<.svn/>
-
-;general dependencies
-; for version requirements see https://docs.platformio.org/en/stable/core/userguide/pkg/cmd_install.html#cmd-pkg-install-requirements
 lib_deps = 
   neroroxxx/RoxMux@^1.6.2
   adafruit/Adafruit SSD1306@~2.5.3
   simsso/ShiftRegister74HC595@^1.3.1
-
-;general serial monitor baud rate
 monitor_speed = 115200
 
-;-------------------------------------------------------
-; ESP32 build environment                              |
-;-------------------------------------------------------
 [env:esp32-s3-devkitc-1]
 platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
-;;add dependencies to general dependencies from [env]
-; lib_deps = 
-;   ${env.lib_deps}
-

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,14 +8,12 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env]
+[env:esp32-s3-devkitc-1]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
 lib_deps = 
 	neroroxxx/RoxMux@^1.6.2
 	adafruit/Adafruit SSD1306@~2.5.3
 	simsso/ShiftRegister74HC595@^1.3.1
 monitor_speed = 115200
-
-[env:esp32-s3-devkitc-1]
-platform = espressif32
-board = esp32-s3-devkitc-1
-framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,18 +8,11 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[platformio]
-default_envs = esp32-s3-devkitc-1
-src_dir = src
-include_dir = src
-description = Task Tracker
-
 [env]
-build_src_filter = +<*> -<.git/> -<.svn/>
 lib_deps = 
-  neroroxxx/RoxMux@^1.6.2
-  adafruit/Adafruit SSD1306@~2.5.3
-  simsso/ShiftRegister74HC595@^1.3.1
+	neroroxxx/RoxMux@^1.6.2
+	adafruit/Adafruit SSD1306@~2.5.3
+	simsso/ShiftRegister74HC595@^1.3.1
 monitor_speed = 115200
 
 [env:esp32-s3-devkitc-1]


### PR DESCRIPTION
Using the GUI
===========

I used [PlatformIO Home](https://docs.platformio.org/en/latest/home/index.html#platformio-home) to modify the project configuration. It removed most of the comments in `platformio.ini` and added some. Instead of reverting these - admittedly unnecessary - changes, I suggest to accept those. _This way PlatformIO Home can be used in future without the need to revert the changes to comments every time._

Remove unnecessary entries
======================

I took advantage of the situation and removed configuration statements which were set to default values or did not have any effect. This reduces the size of the file and - hopefully - the maintenance effort.

Add filter for debugging
==================

For debugging runtime exceptions reading the backtrace can be helpful. In order to understand the backtrace which is written by the framework to the serial port, a backtrace decoder can be used. I [added a filter to the ESP32 environment which handles this][1].

For this to work, do not forget to build in debug-mode. For example in PlatformIO IDE, select as project task 'Advanced' → 'Pre-Debug'. See also [here][2]. Also this only works as long as the serial output is read by PlatformIO.

To decode backtraces from the Wokwi serial monitor, one can use [this python script][3].

[1]: https://github.com/platformio/platform-espressif32/issues/105#issuecomment-945158769  
[2]: https://docs.platformio.org/en/latest/projectconf/build_configurations.html#build-configurations  
[3]: https://github.com/me21/EspArduinoExceptionDecoder