### PR TITLE
Add debug feature to decode backtrace.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,7 @@ lib_deps =
 
 ;general serial monitor baud rate
 monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
 
 [env:native]
 platform = native


### PR DESCRIPTION
For debugging runtime exceptions reading the backtrace can be helpful. In order to understand the backtrace which is written by the framework to the serial port, a backtrace decoder can be used. I [added a filter to the ESP32 environment which handles this][1].

For this to work, do not forget to build in debug-mode. For example in PlatformIO IDE, select as project task 'Advanced' → 'Pre-Debug'. See also [here][2]. Also this only works as long as the serial output is read by PlatformIO.

To decode backtraces from the Wokwi serial monitor, one can use [this python script][3].

[1]: https://github.com/platformio/platform-espressif32/issues/105#issuecomment-945158769  
[2]: https://docs.platformio.org/en/latest/projectconf/build_configurations.html#build-configurations  
[3]: https://github.com/me21/EspArduinoExceptionDecoder