### PR TITLE
Generate documentation for any branch.

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,20 +1,36 @@
 name: generate and deploy documentation
 on:
   push:
-    branches: [ develop ]
 permissions:
   contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Determine Output Directory
+      id: output_dir
+      run: |
+        branch_name="${{ github.ref }}"
+        branch_name="${branch_name#refs/heads/}"
+        if [ "$branch_name" != "develop" ]; then
+          output_dir="./${branch_name//\//_}"
+        else
+          output_dir="."
+        fi
+        echo "DOC_OUTPUT_DIR=$output_dir" >> "$GITHUB_ENV"
+
     - name: generate documentation
       uses: mattnotmitt/doxygen-action@v1.1.0
+
     - name: deploy documentation
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./doc/html
+        destination_dir: ${{ env.DOC_OUTPUT_DIR }}
 

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -18,7 +18,7 @@ jobs:
         branch_name="${{ github.ref }}"
         branch_name="${branch_name#refs/heads/}"
         if [ "$branch_name" != "develop" ]; then
-          output_dir="./${branch_name//\//_}"
+          output_dir="./${branch_name}"
         else
           output_dir="."
         fi


### PR DESCRIPTION
For convenience it would be nice to have a generated documentation for every branch which is under development. Currently there only is a documentation for the `develop` branch.

These modifications add the documentation of every branch to the GitHub page branch. The branch name is used as subdirectory. To access the GitHub page for a specific branch, just add the branch name to the GitHub page URL. For example for this branch, the generated documentation can be found [here](https://task-tracker-systems.github.io/Task-Tracker-Device/feature/generate-documentation-for-every-branch).

:warning: A downside is, that these directories are not cleaned up. Even if a branch is deleted, the directory will continue to live. Manual clean-up is necessary.