### PR TITLE
Generate a list for each branch documentation.

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,10 @@
 name: Clang-Format Check
-on: [push, pull_request]
+
+on:
+  push:
+    branches-ignore:
+      - 'gh-pages'
+
 jobs:
   formatting-check:
     name: check style formatting

--- a/.github/workflows/cleanup-gh-pages.yml
+++ b/.github/workflows/cleanup-gh-pages.yml
@@ -2,6 +2,8 @@ name: Cleanup GitHub Pages Branch Workflow
 
 on:
   push:
+    branches-ignore:
+      - 'gh-pages'
 
 permissions:
   contents: write

--- a/.github/workflows/cleanup-gh-pages.yml
+++ b/.github/workflows/cleanup-gh-pages.yml
@@ -2,9 +2,6 @@ name: Cleanup GitHub Pages Branch Workflow
 
 on:
   push:
-    branches:
-      - develop
-      - main
 
 permissions:
   contents: write

--- a/.github/workflows/cleanup-gh-pages.yml
+++ b/.github/workflows/cleanup-gh-pages.yml
@@ -1,0 +1,93 @@
+name: Cleanup GitHub Pages Branch Workflow
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: write
+
+env:
+  GITHUB_PAGES_BRANCH: 'gh-pages'  # Replace with your GitHub Pages branch name
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch all history for all tags and branches # necessary to list all branches
+        uses: actions/checkout@v2
+      - run: |
+          # List all branches
+          git for-each-ref --format='%(upstream:lstrip=3)' > branches.txt
+          {
+            echo 'BRANCH_LIST<<EOF'
+            cat branches.txt
+            echo EOF
+          } >> "$GITHUB_ENV"
+
+      - name: Checkout GitHub Pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.GITHUB_PAGES_BRANCH }}
+          fetch-depth: 0 # necessary to be able to commit changes
+          
+      - name: List branches, and remove unnecessary files
+        run: |          
+          # Remove unnecessary files
+          echo "branches: $BRANCH_LIST"
+          
+          # Loop through all files in the current Git HEAD
+          git ls-tree -r HEAD --name-only | while read -r file; do
+          
+              # Get the directory part of the file path
+              file_dir=$(dirname "$file")
+              
+              # Initialize a flag to check if the file is part of any directory in DIRS
+              found=false
+              
+              # Loop through each directory in BRANCH_LIST
+              while IFS= read -r line; do
+                
+                # Check if the line is not empty
+                if [[ -n "$line" ]]; then
+                  directory=$line
+                  # Check if the directory is a prefix of the file path
+                  if [[ "$file_dir" == "$directory"* ]]; then
+                      found=true
+                      break
+                  fi
+                fi
+              done <<< "$BRANCH_LIST"
+              
+              # If the file is not part of any directory in BRANCH_LIST, remove it
+              if [ "$found" == "false" ]; then
+                  git rm $file
+              fi
+          done
+
+      - name: Generate Branch List
+        run: |
+          # Generate HTML from the list
+          echo '<html><body><h1>List of Branches</h1><ul>' > index.html    
+          
+          # Loop through each directory in BRANCH_LIST
+          while IFS= read -r line; do
+            # Check if the line is not empty
+            if [[ -n "$line" ]]; then
+              echo "<li><a href=\"$line\"><code>$line</code></a></li>" >> index.html
+            fi
+          done <<< "$BRANCH_LIST"
+          
+          echo '</ul></body></html>' >> index.html
+          git add index.html
+          
+      - name: Commit and push deletions
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git commit --all --allow-empty --message="Cleanup branch directories."
+          git push
+

--- a/.github/workflows/cleanup-gh-pages.yml
+++ b/.github/workflows/cleanup-gh-pages.yml
@@ -14,11 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Fetch all history for all tags and branches # necessary to list all branches
+      - name: Fetch all history for all tags and branches
         uses: actions/checkout@v2
-      - run: |
-          # List all branches
-          git for-each-ref --format='%(upstream:lstrip=3)' > branches.txt
+        with:
+          fetch-depth: 0
+      
+      - name: Generate a list of all branches
+        run: |
+          git branch --remotes --format='%(refname:lstrip=3)' > branches.txt
           {
             echo 'BRANCH_LIST<<EOF'
             cat branches.txt
@@ -31,10 +34,9 @@ jobs:
           ref: ${{ env.GITHUB_PAGES_BRANCH }}
           fetch-depth: 0 # necessary to be able to commit changes
           
-      - name: List branches, and remove unnecessary files
-        run: |          
-          # Remove unnecessary files
-          echo "branches: $BRANCH_LIST"
+      - name: Remove files which are not part of branch-specific directories
+        run: |
+          echo "Process branches: $BRANCH_LIST"
           
           # Loop through all files in the current Git HEAD
           git ls-tree -r HEAD --name-only | while read -r file; do
@@ -65,9 +67,8 @@ jobs:
               fi
           done
 
-      - name: Generate Branch List
+      - name: Generate landing page with branch list
         run: |
-          # Generate HTML from the list
           echo '<html><body><h1>List of Branches</h1><ul>' > index.html    
           
           # Loop through each directory in BRANCH_LIST

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -17,11 +17,7 @@ jobs:
       run: |
         branch_name="${{ github.ref }}"
         branch_name="${branch_name#refs/heads/}"
-        if [ "$branch_name" != "develop" ]; then
-          output_dir="./${branch_name}"
-        else
-          output_dir="."
-        fi
+        output_dir="./${branch_name}"
         echo "DOC_OUTPUT_DIR=$output_dir" >> "$GITHUB_ENV"
 
     - name: generate documentation

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,6 +1,10 @@
 name: generate and deploy documentation
+
 on:
   push:
+    branches-ignore:
+      - 'gh-pages'
+
 permissions:
   contents: write
 


### PR DESCRIPTION
Now the documentation for each branch is generated in a path, which corresponds to the branch name.

All directories in the branch `gh-pages` which do not correspond to a branch are deleted on push to `develop` or `main`.

An entry page is generated which links to the paths for the documentation of all branches.

The documentation for some branches may be unavailable at first. Those branches need to merge with `develop` and push. Only then the documentation will be available.

Resolves #42.
