### PR TITLE
add reset signal to display

### DIFF
--- a/src/board_pins.hpp
+++ b/src/board_pins.hpp
@@ -44,6 +44,13 @@ constexpr PinType on_off = 14;
 namespace i2c_1::pin
 {
 /**
+ * Reset pin.
+ * 
+ * Active low.
+ */
+constexpr PinType res = 35;
+
+/**
  * Serial data.
  */
 constexpr PinType sda = 37;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -9,8 +9,7 @@
 #define SCREEN_HEIGHT 64 // OLED display height, in pixels
 
 // Declaration for an SSD1306 display connected to I2C (SDA, SCL pins)
-#define OLED_RESET -1 // Reset pin # (or -1 if sharing Arduino reset pin)
-Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, board::i2c_1::pin::res);
 
 static lv_disp_draw_buf_t draw_buf;
 static lv_color_t buf[SCREEN_WIDTH * 16];

--- a/wokwi_files/diagram.json
+++ b/wokwi_files/diagram.json
@@ -134,6 +134,13 @@
       "left": -299.15,
       "rotate": 90,
       "attrs": { "value": "220" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "dummy1",
+      "top": -195.6,
+      "left": 637.8,
+      "attrs": { "label": "OLED RST", "flip": "1" }
     }
   ],
   "connections": [
@@ -177,7 +184,9 @@
     [ "esp:37", "oled1:SDA", "orange", [ "h57.6", "v-48", "h38.4" ] ],
     [ "esp:36", "oled1:SCL", "blue", [ "h67.2", "v-48", "h67.2" ] ],
     [ "esp:GND.1", "btn5:2.r", "black", [ "h-38.45", "v-76.8" ] ],
-    [ "btn1:2.l", "led1:C", "black", [ "h-17.2", "v159.4" ] ]
+    [ "btn1:2.l", "led1:C", "black", [ "h-17.2", "v159.4" ] ],
+    [ "esp:35", "dummy1:A", "green", [ "h67.2", "v38.4" ] ],
+    [ "esp:GND.3", "dummy1:C", "black", [ "h57.6", "v19.2", "h38.4" ] ]
   ],
   "dependencies": {}
 }

--- a/wokwi_files/diagram.json
+++ b/wokwi_files/diagram.json
@@ -140,7 +140,7 @@
       "id": "dummy1",
       "top": -195.6,
       "left": 637.8,
-      "attrs": { "label": "OLED RST", "flip": "1" }
+      "attrs": { "label": "dummy for OLED RST" }
     }
   ],
   "connections": [
@@ -185,8 +185,8 @@
     [ "esp:36", "oled1:SCL", "blue", [ "h67.2", "v-48", "h67.2" ] ],
     [ "esp:GND.1", "btn5:2.r", "black", [ "h-38.45", "v-76.8" ] ],
     [ "btn1:2.l", "led1:C", "black", [ "h-17.2", "v159.4" ] ],
-    [ "esp:35", "dummy1:A", "green", [ "h67.2", "v38.4" ] ],
-    [ "esp:GND.3", "dummy1:C", "black", [ "h57.6", "v19.2", "h38.4" ] ]
+    [ "oled1:VCC", "dummy1:A", "red", [ "v-38.4", "h67.35", "v76.8" ] ],
+    [ "esp:35", "dummy1:C", "green", [ "h67.2", "v48" ] ]
   ],
   "dependencies": {}
 }


### PR DESCRIPTION
- define reset signal
- add connection to a dummy in Wokwi model, as the model's display board is missing a reset pin
- configure display library to use reset pin (it does configure the pin to output mode)

In contrast to #66, this does not remove the call to `delay()`.

This resolves #38.