### PR TITLE
Unify formatting in PlatformIO project configuration.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,23 +29,20 @@ build_src_filter = +<*> -<.git/> -<.svn/>
 ;general dependencies
 ; for version requirements see https://docs.platformio.org/en/stable/core/userguide/pkg/cmd_install.html#cmd-pkg-install-requirements
 lib_deps = 
-  adafruit/Adafruit SSD1306@~2.5.3
-  lvgl@^8.3
-
-build_flags =
-  -DLV_CONF_INCLUDE_SIMPLE    ; lvgl: use a config file located in source directory
-  -I"src"                     ; adds src directory to be used as include directory
-
-;general serial monitor baud rate
+	adafruit/Adafruit SSD1306@~2.5.3
+	lvgl@^8.3
+build_flags = 
+	-DLV_CONF_INCLUDE_SIMPLE    ; lvgl: use a config file located in source directory
+	-I"src"                     ; adds src directory to be used as include directory
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 
 [env:native]
 platform = native
 lib_deps =
-    ArduinoFake
+	ArduinoFake
 build_flags =
-    -Wno-deprecated ; Workaround for https://github.com/FabioBatSilva/ArduinoFake/pull/41#issuecomment-1440550553
+	-Wno-deprecated ; Workaround for https://github.com/FabioBatSilva/ArduinoFake/pull/41#issuecomment-1440550553
 
 ;-------------------------------------------------------
 ; ESP32 build environment                              |


### PR DESCRIPTION
Tabs are apparently default indentation (created by PlatformIO IDE Home).

We had different indentations. I checked what PlatformIO does use by default. And applied `\t`.
I did not change indentation between an expression and a comment. Because this only works well if the tab width is everywhere the same.