### PR TITLE
refactor task class

### DIFF
--- a/lib/tasks/Task.cpp
+++ b/lib/tasks/Task.cpp
@@ -1,5 +1,4 @@
 #include "Task.hpp"
-#include <Arduino.h>
 #include <type_traits>
 
 const Task::String &Task::getLabel() const
@@ -17,7 +16,7 @@ void Task::start()
     if (!isRunning)
     {
         isRunning = true;
-        timestampStart = millis() / 1000;
+        timestampStart = std::chrono::round<DurationFraction>(Clock::now());
     }
 }
 
@@ -26,7 +25,7 @@ void Task::stop()
     if (isRunning)
     {
         isRunning = false;
-        recordedDuration += (millis() / 1000) - timestampStart;
+        recordedDuration += std::chrono::duration_cast<Duration>(Clock::now() - timestampStart);
     }
 }
 

--- a/lib/tasks/Task.cpp
+++ b/lib/tasks/Task.cpp
@@ -25,7 +25,7 @@ void Task::stop()
     if (isRunning)
     {
         isRunning = false;
-        recordedDuration += std::chrono::duration_cast<Duration>(Clock::now() - timestampStart);
+        recordedDuration += std::chrono::duration_cast<DurationFraction>(Clock::now() - timestampStart);
     }
 }
 
@@ -36,5 +36,5 @@ void Task::setLabel(const String &label)
 
 Task::Duration Task::getRecordedDuration() const
 {
-    return recordedDuration;
+    return std::chrono::round<Duration>(recordedDuration);
 }

--- a/lib/tasks/Task.cpp
+++ b/lib/tasks/Task.cpp
@@ -7,26 +7,29 @@ const Task::String &Task::getLabel() const
 }
 
 Task::Task(const String &newLabel, const Duration elapsedTime)
-    : recordedDuration(elapsedTime), label(newLabel), isRunning(false)
+    : recordedDuration(elapsedTime), label(newLabel), state(State::IDLE)
 {
 }
 
 void Task::start()
 {
-    if (!isRunning)
-    {
-        isRunning = true;
-        timestampStart = std::chrono::round<DurationFraction>(Clock::now());
-    }
+    state = State::RUNNING;
+    timestampStart = std::chrono::round<DurationFraction>(Clock::now());
 }
 
 void Task::stop()
 {
-    if (isRunning)
+    // this check is necessary, as else the timestamp using for comparison will be invalid
+    if (state == State::RUNNING)
     {
-        isRunning = false;
+        state = State::IDLE;
         recordedDuration += std::chrono::duration_cast<DurationFraction>(Clock::now() - timestampStart);
     }
+}
+
+bool Task::isRunning() const
+{
+    return state == State::RUNNING;
 }
 
 void Task::setLabel(const String &label)

--- a/lib/tasks/Task.cpp
+++ b/lib/tasks/Task.cpp
@@ -6,8 +6,8 @@ const Task::String &Task::getLabel() const
     return label;
 }
 
-Task::Task(const String &newLabel, const Duration elapsedTime)
-    : recordedDuration(elapsedTime), label(newLabel), state(State::IDLE)
+Task::Task(const ID id, const String &newLabel, const Duration elapsedTime)
+    : id(id), recordedDuration(elapsedTime), label(newLabel), state(State::IDLE)
 {
 }
 
@@ -45,4 +45,9 @@ Task::Duration Task::getRecordedDuration()
         start();
     }
     return std::chrono::round<Duration>(recordedDuration);
+}
+
+Task::ID Task::getId() const
+{
+    return id;
 }

--- a/lib/tasks/Task.cpp
+++ b/lib/tasks/Task.cpp
@@ -37,7 +37,12 @@ void Task::setLabel(const String &label)
     this->label = label;
 }
 
-Task::Duration Task::getRecordedDuration() const
+Task::Duration Task::getRecordedDuration()
 {
+    if (isRunning())
+    {
+        stop();
+        start();
+    }
     return std::chrono::round<Duration>(recordedDuration);
 }

--- a/lib/tasks/Task.hpp
+++ b/lib/tasks/Task.hpp
@@ -52,10 +52,16 @@ class Task
     const String &getLabel() const;
     void setLabel(const String &label);
     Duration getRecordedDuration() const;
+    bool isRunning() const;
 
   private:
     String label;
-    bool isRunning;
+    enum class State
+    {
+        IDLE,
+        RUNNING,
+    };
+    State state;
 
     /**
      * Internal representation in order to reduce loss of precision.

--- a/lib/tasks/Task.hpp
+++ b/lib/tasks/Task.hpp
@@ -32,7 +32,7 @@ class Task
      * \endinternal
      */
     typedef std::wstring String;
-    Task(const String &newLabel, const Duration elapsedTime = Duration(0U));
+    Task(const String &newLabel, const Duration elapsedTime = Duration::zero());
 
     /**
      * Starts/continues capturing duration
@@ -54,10 +54,14 @@ class Task
     Duration getRecordedDuration() const;
 
   private:
-    Duration recordedDuration;
     String label;
     bool isRunning;
-    typedef std::chrono::system_clock Clock;
+
+    /**
+     * Internal representation in order to reduce loss of precision.
+     */
     typedef std::chrono::milliseconds DurationFraction;
+    DurationFraction recordedDuration;
+    typedef std::chrono::system_clock Clock;
     std::chrono::time_point<Clock, DurationFraction> timestampStart;
 };

--- a/lib/tasks/Task.hpp
+++ b/lib/tasks/Task.hpp
@@ -32,7 +32,7 @@ class Task
      * \endinternal
      */
     typedef std::wstring String;
-    Task(const String &newLabel, const Duration elapsedTime = 0U);
+    Task(const String &newLabel, const Duration elapsedTime = Duration(0U));
 
     /**
      * Starts/continues capturing duration

--- a/lib/tasks/Task.hpp
+++ b/lib/tasks/Task.hpp
@@ -38,7 +38,6 @@ class Task
      * Starts/continues capturing duration
      *
      * Sets the state of the task to "running".
-     * Has no effect if already running.
      */
     void start();
 
@@ -51,7 +50,15 @@ class Task
     void stop();
     const String &getLabel() const;
     void setLabel(const String &label);
-    Duration getRecordedDuration() const;
+
+    /**
+     * Gets the recorded duration.
+     * 
+     * Does also consider an already begun interval if the task is running.
+     * 
+     * \returns the accumulated duration
+     */
+    Duration getRecordedDuration();
     bool isRunning() const;
 
   private:

--- a/lib/tasks/Task.hpp
+++ b/lib/tasks/Task.hpp
@@ -25,6 +25,11 @@ class Task
     typedef std::chrono::seconds Duration;
 
     /**
+     * Task ID.
+     */
+    typedef unsigned int ID;
+
+    /**
      * String type used for labels of the task.
      *
      * \internal
@@ -32,7 +37,7 @@ class Task
      * \endinternal
      */
     typedef std::wstring String;
-    Task(const String &newLabel, const Duration elapsedTime = Duration::zero());
+    Task(const ID id, const String &newLabel, const Duration elapsedTime = Duration::zero());
 
     /**
      * Starts/continues capturing duration
@@ -60,8 +65,10 @@ class Task
      */
     Duration getRecordedDuration();
     bool isRunning() const;
+    ID getId() const;
 
   private:
+    const ID id;
     String label;
     enum class State
     {

--- a/lib/tasks/Task.hpp
+++ b/lib/tasks/Task.hpp
@@ -2,7 +2,7 @@
  * \file .
  */
 #pragma once
-#include <cstdint>
+#include <chrono>
 #include <string>
 
 /**
@@ -22,7 +22,7 @@ class Task
      * Must be big enough to hold a duration of 10 years in milliseconds.
      * \endinternal
      */
-    typedef std::uint32_t Duration;
+    typedef std::chrono::seconds Duration;
 
     /**
      * String type used for labels of the task.
@@ -57,5 +57,7 @@ class Task
     Duration recordedDuration;
     String label;
     bool isRunning;
-    unsigned long timestampStart;
+    typedef std::chrono::system_clock Clock;
+    typedef std::chrono::milliseconds DurationFraction;
+    std::chrono::time_point<Clock, DurationFraction> timestampStart;
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,8 @@ lib_deps =
 build_flags = 
 	-DLV_CONF_INCLUDE_SIMPLE    ; lvgl: use a config file located in source directory
 	-I"src"                     ; adds src directory to be used as include directory
-	-std=c++17                  ; necessary for using modern STL
+	-std=gnu++17                  ; necessary for using modern STL
+build_unflags = -std=gnu++11    ; necessary to be able to specify a different language standard
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,6 +34,7 @@ lib_deps =
 build_flags = 
 	-DLV_CONF_INCLUDE_SIMPLE    ; lvgl: use a config file located in source directory
 	-I"src"                     ; adds src directory to be used as include directory
+	-std=c++17                  ; necessary for using modern STL
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 

--- a/test/test_tasks/task.cpp
+++ b/test/test_tasks/task.cpp
@@ -14,13 +14,13 @@ void tearDown()
 
 void test_get_label()
 {
-    const Task task(label);
+    const Task task(0, label);
     TEST_ASSERT_EQUAL_STRING(label.c_str(), task.getLabel().c_str());
 }
 
 void test_time_elapses()
 {
-    Task task(label);
+    Task task(1, label);
     constexpr unsigned int durationToTest = 2;
     TEST_ASSERT_FALSE(task.isRunning());
     TEST_ASSERT_EQUAL_UINT(0U, task.getRecordedDuration().count());
@@ -36,12 +36,20 @@ void test_time_elapses()
     TEST_ASSERT_EQUAL_UINT(durationToTest, task.getRecordedDuration().count());
 }
 
+void test_task_id()
+{
+    const Task::ID idToTest = 2;
+    Task task(idToTest, L"test");
+    TEST_ASSERT_EQUAL_UINT(idToTest, task.getId());
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
 
     RUN_TEST(test_get_label);
     RUN_TEST(test_time_elapses);
+    RUN_TEST(test_task_id);
 
     UNITY_END();
 }

--- a/test/test_tasks/task.cpp
+++ b/test/test_tasks/task.cpp
@@ -1,10 +1,8 @@
 #include "Task.hpp"
-#include <ArduinoFake.h>
+#include <thread>
 #include <unity.h>
 
 static const Task::String label(L"äüöß");
-
-using namespace fakeit;
 
 void setUp()
 {
@@ -23,12 +21,12 @@ void test_get_label()
 void test_time_elapses()
 {
     Task task(label);
+    constexpr unsigned int durationToTest = 2;
     TEST_ASSERT_EQUAL_UINT(0U, task.getRecordedDuration().count());
-    When(Method(ArduinoFake(), millis)).Return(0);
     task.start();
-    When(Method(ArduinoFake(), millis)).Return(2000);
+    std::this_thread::sleep_for(Task::Duration(durationToTest));
     task.stop();
-    TEST_ASSERT_EQUAL_UINT(2U, task.getRecordedDuration().count());
+    TEST_ASSERT_EQUAL_UINT(durationToTest, task.getRecordedDuration().count());
 }
 
 int main(int argc, char **argv)

--- a/test/test_tasks/task.cpp
+++ b/test/test_tasks/task.cpp
@@ -22,10 +22,14 @@ void test_time_elapses()
 {
     Task task(label);
     constexpr unsigned int durationToTest = 2;
+    TEST_ASSERT_FALSE(task.isRunning());
     TEST_ASSERT_EQUAL_UINT(0U, task.getRecordedDuration().count());
     task.start();
-    std::this_thread::sleep_for(Task::Duration(durationToTest));
+    std::this_thread::sleep_for(Task::Duration(durationToTest / 2));
+    TEST_ASSERT_TRUE(task.isRunning());
+    std::this_thread::sleep_for(Task::Duration(durationToTest / 2));
     task.stop();
+    TEST_ASSERT_FALSE(task.isRunning());
     TEST_ASSERT_EQUAL_UINT(durationToTest, task.getRecordedDuration().count());
 }
 

--- a/test/test_tasks/task.cpp
+++ b/test/test_tasks/task.cpp
@@ -23,12 +23,12 @@ void test_get_label()
 void test_time_elapses()
 {
     Task task(label);
-    TEST_ASSERT_EQUAL_UINT(0U, task.getRecordedDuration());
+    TEST_ASSERT_EQUAL_UINT(0U, task.getRecordedDuration().count());
     When(Method(ArduinoFake(), millis)).Return(0);
     task.start();
     When(Method(ArduinoFake(), millis)).Return(2000);
     task.stop();
-    TEST_ASSERT_EQUAL_UINT(2U, task.getRecordedDuration());
+    TEST_ASSERT_EQUAL_UINT(2U, task.getRecordedDuration().count());
 }
 
 int main(int argc, char **argv)

--- a/test/test_tasks/task.cpp
+++ b/test/test_tasks/task.cpp
@@ -25,9 +25,12 @@ void test_time_elapses()
     TEST_ASSERT_FALSE(task.isRunning());
     TEST_ASSERT_EQUAL_UINT(0U, task.getRecordedDuration().count());
     task.start();
-    std::this_thread::sleep_for(Task::Duration(durationToTest / 2));
     TEST_ASSERT_TRUE(task.isRunning());
     std::this_thread::sleep_for(Task::Duration(durationToTest / 2));
+    TEST_ASSERT_EQUAL_UINT(durationToTest / 2, task.getRecordedDuration().count());
+    TEST_ASSERT_TRUE(task.isRunning());
+    std::this_thread::sleep_for(Task::Duration(durationToTest / 2));
+    TEST_ASSERT_TRUE(task.isRunning());
     task.stop();
     TEST_ASSERT_FALSE(task.isRunning());
     TEST_ASSERT_EQUAL_UINT(durationToTest, task.getRecordedDuration().count());


### PR DESCRIPTION
Resolves #73.

- [x] do not use (directly) `<Arduino.h>`, use an abstraction instead
- [x] do not check state in `start()` this allows to restart an interval at any time
- [x] define member function to get the current state
- [x] define `Duration` as `seconds`
- [x] add the concept of IDs