### PR TITLE
expose character type of `serial_port` adapter

### DIFF
--- a/lib/3rd_party_adapters/SerialOutputStreamBuffer.hpp
+++ b/lib/3rd_party_adapters/SerialOutputStreamBuffer.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <serial_port.hpp>
 #include <streambuf>
 
 /**
  * Controls output of a character sequence to serial port.
  */
-class SerialOutputStreamBuffer : public std::streambuf
+class SerialOutputStreamBuffer : public std::basic_streambuf<serial_port::CharType>
 {
   private:
     char_type *const buffer_begin;

--- a/lib/3rd_party_adapters/serial_port.cpp
+++ b/lib/3rd_party_adapters/serial_port.cpp
@@ -5,13 +5,13 @@
 
 static SerialOutputStreamBuffer::char_type serial_output_buffer[255];
 static SerialOutputStreamBuffer serialOutputStreamBuffer(std::begin(serial_output_buffer), std::end(serial_output_buffer));
-static std::ostream serialOutputStream(&serialOutputStreamBuffer);
+static std::basic_ostream<SerialOutputStreamBuffer::char_type> serialOutputStream(&serialOutputStreamBuffer);
 
 namespace serial_port
 {
 static StringHandler incomingStringHandler;
 
-std::ostream &cout = serialOutputStream;
+std::basic_ostream<CharType> &cout = serialOutputStream;
 
 void initialize()
 {
@@ -21,12 +21,12 @@ void initialize()
     delay(100);
 }
 
-std::string readLine()
+String readLine()
 {
-    return std::string(Serial.readStringUntil('\n').c_str());
+    return String(Serial.readStringUntil('\n').c_str());
 }
 
-std::optional<std::string> getLine()
+std::optional<String> getLine()
 {
     if (Serial.available() > 0)
     {
@@ -61,8 +61,8 @@ void serialEvent()
         }
         else
         {
-            static std::string inputBuffer{};
-            const char inChar = inData;
+            static serial_port::String inputBuffer{};
+            const serial_port::String::value_type inChar = inData;
             inputBuffer += inChar;
             // if the incoming character is a newline, call handler
             if (inChar == '\n' || inChar == '\r')

--- a/lib/3rd_party_adapters/serial_port.cpp
+++ b/lib/3rd_party_adapters/serial_port.cpp
@@ -2,6 +2,7 @@
 #include "SerialOutputStreamBuffer.hpp"
 #include <Arduino.h>
 #include <iterator>
+#include <type_traits>
 
 static SerialOutputStreamBuffer::char_type serial_output_buffer[255];
 static SerialOutputStreamBuffer serialOutputStreamBuffer(std::begin(serial_output_buffer), std::end(serial_output_buffer));
@@ -9,6 +10,8 @@ static std::basic_ostream<SerialOutputStreamBuffer::char_type> serialOutputStrea
 
 namespace serial_port
 {
+static_assert(std::is_same_v<CharType, std::remove_cv_t<std::remove_reference_t<decltype(*Serial.readString().c_str())>>>);
+
 static StringHandler incomingStringHandler;
 
 std::basic_ostream<CharType> &cout = serialOutputStream;

--- a/lib/application_business_rules/serial_port.hpp
+++ b/lib/application_business_rules/serial_port.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <array>
 #include <functional>
 #include <optional>

--- a/lib/application_business_rules/serial_port.hpp
+++ b/lib/application_business_rules/serial_port.hpp
@@ -7,11 +7,21 @@
 namespace serial_port
 {
 /**
+ * Character type used by serial port.
+ */
+typedef char CharType;
+
+/**
+ * String type provided by serial port.
+ */
+typedef std::basic_string<CharType> String;
+
+/**
  * Output stream for characters to serial port.
  * 
  * \pre call \ref initialize() before using
  */
-extern std::ostream &cout;
+extern std::basic_ostream<CharType> &cout;
 
 /**
  * Configures and initializes serial port.
@@ -25,7 +35,7 @@ void initialize();
  * It will wait for data for the duration of the timeout.
  * \returns an empty string in case no data is read
  */
-std::string readLine();
+String readLine();
 
 /**
  * Gets a line from serial port.
@@ -33,12 +43,12 @@ std::string readLine();
  * Interprets the end of line as `\n`.
  * \returns an object that does not contain a value in case no data is already available.
  */
-std::optional<std::string> getLine();
+std::optional<String> getLine();
 
 /**
  * Callback which can handle strings.
  */
-typedef std::function<void(const std::string &)> StringHandler;
+typedef std::function<void(const String &)> StringHandler;
 
 /**
  * Set the handler to be called when a full line has been received via serial_port.
@@ -56,8 +66,8 @@ void setCallbackForLineReception(const StringHandler &callback);
  * \param bitArray the bits to output
  * \returns the stream
  */
-template <std::size_t BITS>
-std::ostream &operator<<(std::ostream &os, const std::array<bool, BITS> &bitArray)
+template <std::size_t BITS, typename CharType = char>
+std::ostream &operator<<(std::basic_ostream<CharType> &os, const std::array<bool, BITS> &bitArray)
 {
     os << "0b";
     for (const bool bit : bitArray)

--- a/test/test_serial_port/test_serial_port.cpp
+++ b/test/test_serial_port/test_serial_port.cpp
@@ -33,7 +33,7 @@ void test_getLine()
 
     {
         // Test non-empty
-        constexpr auto testString = "Hello World";
+        constexpr const serial_port::CharType *const testString = "Hello World";
         When(Method(ArduinoFake(Serial), available)).Return(std::strlen(testString) + 1);
         When(Method(ArduinoFake(Serial), readStringUntil)).Return(testString);
         const auto result = serial_port::getLine();
@@ -41,9 +41,9 @@ void test_getLine()
     }
 }
 
-static std::string receivedLine = "foo";
+static serial_port::String receivedLine = "foo";
 
-static void lineHandler(const std::string &line)
+static void lineHandler(const serial_port::String &line)
 {
     receivedLine = line;
 }
@@ -55,7 +55,7 @@ void test_subscribeToLine()
 {
     serial_port::setCallbackForLineReception(lineHandler);
 
-    constexpr auto testLine = "C++\n";
+    constexpr const serial_port::CharType *const testLine = "C++\n";
     for (std::size_t i = 0; i < std::strlen(testLine); ++i)
     {
         When(Method(ArduinoFake(Serial), available)).Return(1, 0); // every time only 1 char is available


### PR DESCRIPTION
The intention is that this allows to

- use that type as for example with the `SerialOutputStreamBuffer`
- clarify which parts of the software use the same type on purpose