### PR TITLE
add functions to trim strings

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -29,3 +29,5 @@ jobs:
       run: platformio run --verbose
     - name: On native platform run tests for 'tasks'
       run: platformio test --verbose --environment test_native_tasks
+    - name: On native platform run tests for 'trim'
+      run: platformio test --verbose --environment test_native_trim

--- a/lib/application_business_rules/trim.hpp
+++ b/lib/application_business_rules/trim.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/lib/application_business_rules/trim.hpp
+++ b/lib/application_business_rules/trim.hpp
@@ -14,7 +14,18 @@ SequenceT &ltrim(SequenceT &input, const std::locale &locale = std::locale())
 }
 
 template <typename SequenceT>
+SequenceT &rtrim(SequenceT &input, const std::locale &locale = std::locale())
+{
+    const auto end_trimmed = std::find_if(
+        std::rbegin(input),
+        std::rend(input),
+        [&](const auto ch) { return !std::isspace(ch, locale); });
+    input = SequenceT(std::begin(input), end_trimmed.base());
+    return input;
+}
+
+template <typename SequenceT>
 SequenceT &trim(SequenceT &input, const std::locale &locale = std::locale())
 {
-    return ltrim(input);
+    return rtrim(ltrim(input));
 }

--- a/lib/application_business_rules/trim.hpp
+++ b/lib/application_business_rules/trim.hpp
@@ -1,20 +1,27 @@
 #pragma once
 #include <iterator>
 #include <locale>
+#include <utility>
 
 template <typename SequenceT>
-SequenceT &ltrim(SequenceT &input, const std::locale &locale = std::locale())
+SequenceT ltrim(SequenceT &&input, const std::locale &locale = std::locale())
 {
     const auto begin_trimmed = std::find_if(
         std::begin(input),
         std::end(input),
         [&](const auto ch) { return !std::isspace(ch, locale); });
-    input = SequenceT(begin_trimmed, std::end(input));
+    return SequenceT(begin_trimmed, std::end(input));
+}
+
+template <typename SequenceT>
+SequenceT &ltrim(SequenceT &input, const std::locale &locale = std::locale())
+{
+    input = ltrim(std::move(input));
     return input;
 }
 
 template <typename SequenceT>
-SequenceT &rtrim(SequenceT &input, const std::locale &locale = std::locale())
+SequenceT rtrim(SequenceT &&input, const std::locale &locale = std::locale())
 {
     const auto end_trimmed = std::find_if(
         std::rbegin(input),
@@ -25,7 +32,14 @@ SequenceT &rtrim(SequenceT &input, const std::locale &locale = std::locale())
 }
 
 template <typename SequenceT>
-SequenceT &trim(SequenceT &input, const std::locale &locale = std::locale())
+SequenceT &rtrim(SequenceT &input, const std::locale &locale = std::locale())
+{
+    input = rtrim(std::move(input));
+    return input;
+}
+
+template <typename SequenceT>
+SequenceT &trim(SequenceT &&input, const std::locale &locale = std::locale())
 {
     return rtrim(ltrim(input));
 }

--- a/lib/application_business_rules/trim.hpp
+++ b/lib/application_business_rules/trim.hpp
@@ -27,8 +27,7 @@ SequenceT rtrim(SequenceT &&input, const std::locale &locale = std::locale())
         std::rbegin(input),
         std::rend(input),
         [&](const auto ch) { return !std::isspace(ch, locale); });
-    input = SequenceT(std::begin(input), end_trimmed.base());
-    return input;
+    return SequenceT(std::begin(input), end_trimmed.base());
 }
 
 template <typename SequenceT>

--- a/lib/application_business_rules/trim.hpp
+++ b/lib/application_business_rules/trim.hpp
@@ -1,8 +1,20 @@
 #pragma once
+#include <iterator>
 #include <locale>
+
+template <typename SequenceT>
+SequenceT &ltrim(SequenceT &input, const std::locale &locale = std::locale())
+{
+    const auto begin_trimmed = std::find_if(
+        std::begin(input),
+        std::end(input),
+        [&](const auto ch) { return !std::isspace(ch, locale); });
+    input = SequenceT(begin_trimmed, std::end(input));
+    return input;
+}
 
 template <typename SequenceT>
 SequenceT &trim(SequenceT &input, const std::locale &locale = std::locale())
 {
-    return input;
+    return ltrim(input);
 }

--- a/lib/application_business_rules/trim.hpp
+++ b/lib/application_business_rules/trim.hpp
@@ -39,7 +39,13 @@ SequenceT &rtrim(SequenceT &input, const std::locale &locale = std::locale())
 }
 
 template <typename SequenceT>
-SequenceT &trim(SequenceT &&input, const std::locale &locale = std::locale())
+SequenceT trim(SequenceT &&input, const std::locale &locale = std::locale())
+{
+    return rtrim(ltrim(std::move(input)));
+}
+
+template <typename SequenceT>
+SequenceT &trim(SequenceT &input, const std::locale &locale = std::locale())
 {
     return rtrim(ltrim(input));
 }

--- a/lib/application_business_rules/trim.hpp
+++ b/lib/application_business_rules/trim.hpp
@@ -1,1 +1,8 @@
 #pragma once
+#include <locale>
+
+template <typename SequenceT>
+SequenceT &trim(SequenceT &input, const std::locale &locale = std::locale())
+{
+    return input;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -80,3 +80,10 @@ debug_test = test_serial_port
 lib_deps = 
 	${test_native.lib_deps}
 	3rd_party_adapters
+
+[env:test_native_trim]
+extends = test_native
+test_filter = test_trim
+debug_test = test_trim
+lib_deps = 
+	${test_native.lib_deps}

--- a/test/test_trim/test_trim.cpp
+++ b/test/test_trim/test_trim.cpp
@@ -33,12 +33,23 @@ void test_trimPrefix()
     TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringWithFront.c_str());
 }
 
+void test_trimEmpty()
+{
+    const std::string stringExpected = "";
+    std::string stringEmpty = stringExpected;
+
+    trim(stringEmpty);
+
+    TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringEmpty.c_str());
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
 
     RUN_TEST(test_nothingToTrim);
     RUN_TEST(test_trimPrefix);
+    RUN_TEST(test_trimEmpty);
 
     UNITY_END();
 }

--- a/test/test_trim/test_trim.cpp
+++ b/test/test_trim/test_trim.cpp
@@ -43,6 +43,16 @@ void test_trimEmpty()
     TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringEmpty.c_str());
 }
 
+void test_trimWhitespaceOnly()
+{
+    const std::string stringExpected = "";
+    std::string stringWhitespaces = "\t \n \r ";
+
+    trim(stringWhitespaces);
+
+    TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringWhitespaces.c_str());
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
@@ -50,6 +60,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_nothingToTrim);
     RUN_TEST(test_trimPrefix);
     RUN_TEST(test_trimEmpty);
+    RUN_TEST(test_trimWhitespaceOnly);
 
     UNITY_END();
 }

--- a/test/test_trim/test_trim.cpp
+++ b/test/test_trim/test_trim.cpp
@@ -1,0 +1,22 @@
+#include <fakeit.hpp>
+#include <trim.hpp>
+#include <unity.h>
+
+using namespace fakeit;
+
+void setUp()
+{
+}
+
+void tearDown()
+{
+}
+
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST();
+
+    UNITY_END();
+}

--- a/test/test_trim/test_trim.cpp
+++ b/test/test_trim/test_trim.cpp
@@ -1,4 +1,5 @@
 #include <fakeit.hpp>
+#include <string>
 #include <trim.hpp>
 #include <unity.h>
 
@@ -12,11 +13,21 @@ void tearDown()
 {
 }
 
+void test_nothingToTrim()
+{
+    std::string stringFine = "Hello World";
+    const std::string stringExpected = stringFine;
+
+    trim(stringFine);
+
+    TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringFine.c_str());
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
 
-    RUN_TEST();
+    RUN_TEST(test_nothingToTrim);
 
     UNITY_END();
 }

--- a/test/test_trim/test_trim.cpp
+++ b/test/test_trim/test_trim.cpp
@@ -23,11 +23,22 @@ void test_nothingToTrim()
     TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringFine.c_str());
 }
 
+void test_trimPrefix()
+{
+    const std::string stringExpected = "Hello World";
+    std::string stringWithFront = "\t " + stringExpected;
+
+    trim(stringWithFront);
+
+    TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringWithFront.c_str());
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
 
     RUN_TEST(test_nothingToTrim);
+    RUN_TEST(test_trimPrefix);
 
     UNITY_END();
 }

--- a/test/test_trim/test_trim.cpp
+++ b/test/test_trim/test_trim.cpp
@@ -53,6 +53,16 @@ void test_trimWhitespaceOnly()
     TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringWhitespaces.c_str());
 }
 
+void test_trimSuffix()
+{
+    const std::string stringExpected = "Hello World";
+    std::string stringWhithSuffix = stringExpected + "\t \n \r ";
+
+    trim(stringWhithSuffix);
+
+    TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringWhithSuffix.c_str());
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
@@ -61,6 +71,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_trimPrefix);
     RUN_TEST(test_trimEmpty);
     RUN_TEST(test_trimWhitespaceOnly);
+    RUN_TEST(test_trimSuffix);
 
     UNITY_END();
 }

--- a/test/test_trim/test_trim.cpp
+++ b/test/test_trim/test_trim.cpp
@@ -63,6 +63,25 @@ void test_trimSuffix()
     TEST_ASSERT_EQUAL_STRING(stringExpected.c_str(), stringWhithSuffix.c_str());
 }
 
+void test_trimBoth()
+{
+    const std::string expected = "Hello World";
+    std::string padded = " \t " + expected + " \n ";
+
+    const std::string result = trim(padded);
+
+    TEST_ASSERT_EQUAL_STRING(expected.c_str(), result.c_str());
+    TEST_ASSERT_EQUAL_STRING(expected.c_str(), padded.c_str());
+}
+
+void test_trimRValue()
+{
+    const auto rvalueString = []() { return std::string("  Hello World  "); };
+    const std::string result = trim(rvalueString());
+
+    TEST_ASSERT_EQUAL_STRING("Hello World", result.c_str());
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
@@ -72,6 +91,8 @@ int main(int argc, char **argv)
     RUN_TEST(test_trimEmpty);
     RUN_TEST(test_trimWhitespaceOnly);
     RUN_TEST(test_trimSuffix);
+    RUN_TEST(test_trimBoth);
+    RUN_TEST(test_trimRValue);
 
     UNITY_END();
 }


### PR DESCRIPTION
This code has originally been written for #82. But before that has been merged, the need for the trim functions became obsolete due to changes in the code of #82. Thus the commits which were originally part of #82 have been rebased. This way these functions can be added later if necessary.

- [ ] make sure this function is actually necessary
- [ ] ensure sufficient code coverage