### PR TITLE
support recognition of C++17 by clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,5 @@
 BasedOnStyle: Microsoft
 ReflowComments: false
 ColumnLimit: 0
+Standard: c++17
 

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -14,5 +14,6 @@ jobs:
     - name: Run clang-format style check.
       uses: jidicula/clang-format-action@v4.11.0
       with:
+        clang-format-version: '17'
         fallback-style: 'none'
 


### PR DESCRIPTION
Specify the language standard to format to.

Else there may be problems with code like this:

    (std::tuple_size_v<decltype(options)> > 0)

Different versions of clang-format format differently. This can lead to failures of the hosted clang-format test.