### PR TITLE
Configure receiving serial monitor for newlines.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,6 +65,7 @@ void setup(char const *programIdentificationString)
     pinMode(board::led::pin::task4, OUTPUT);
     pinMode(board::buzzer::pin::on_off, OUTPUT);
     setup_display();
+    serial_port::cout << "\x1b[20h"; // Tell the terminal to use CR/LF for newlines instead of just CR.
     serial_port::cout << std::endl
                       << " begin program '" << programIdentificationString << std::endl;
     serial_port::setCallbackForLineReception([](const serial_port::String &commandLine) {


### PR DESCRIPTION
The Wokwi VS Code Extension uses a different terminal beginning with [version 2.1.0](https://marketplace.visualstudio.com/items/Wokwi.wokwi-vscode/changelog). The version used there does not do an automatic carriage return.

This can be changed by changing the 'Line feed/new line' mode of the terminal to 'new line'.

With that change, using Wokwi VS Code Extension version 2.1.0 renders properly aligned lines again. Using older versions will work as well, but the mode control sequence will be printed to Wokwi's integrated terminal *once* at the beginning of the program:

```plain
[20h
```

See also

- [VT100 User Guide Chapter 3 Programmer Information](https://vt100.net/docs/vt100-ug/chapter3.html)
- [a project log with a list of useful control characters and ANSI sequences ](https://hackaday.io/project/17983-dl1416smarterm-led-computerterminal/log/48628-v10-terminal-functionality)
- https://github.com/wokwi/wokwi-features/issues/699#issuecomment-1863932289