### PR TITLE
Document decision about putting packages/modules/... into `lib_dir`

### DIFF
--- a/doc/decisions/dr-002.md
+++ b/doc/decisions/dr-002.md
@@ -1,0 +1,42 @@
+DR002 Root Directory for the Package's source files {#dr_002}
+===================================================
+
+Context
+-------
+
+I am not sure in which directory to put the packages: `src` or `lib`.
+
+- IMHO `lib` sounds like source code, which originates from somewhere else and has been added to this project.
+- PlatformIO [describes](https://docs.platformio.org/en/latest/projectconf/sections/platformio/options/directory/lib_dir.html#lib-dir) the `lib` directory as:
+  > You can put your own/private libraries here.
+
+- [@valeros](https://github.com/valeros) (Head of System Integration at PlatformIO Labs) [writes](https://piolabs.com/blog/insights/unit-testing-part-1.html#adding-first-tests)
+  > We recommend to split any application into isolated modules and place them into the special `lib` folder in the root of the project.
+
+The packages in question are not planed to be used in other projects.
+The packages may have dependencies through well defined interfaces.
+
+What are the consequences of this decision anyway? I am open for comments!
+
+Decision
+--------
+
+I think I found an [answer](https://community.platformio.org/t/why-separate-src-and-lib/30509) to the [question](https://github.com/dhebbeker/task-tracker/pull/31#pullrequestreview-1435060978) about whether to put packages (modules) into `src` or `lib` directory.
+
+The PlatformIO documentation [explains](https://docs.platformio.org/en/stable/advanced/unit-testing/structure/shared-code.html#shared-code):
+
+> By default, PlatformIO does not build the main source code from the [src_dir](https://docs.platformio.org/en/stable/projectconf/sections/platformio/options/directory/src_dir.html#projectconf-pio-src-dir) folder in pair with a test source code. [...] We recommend splitting the source code into multiple components and placing them into the [lib_dir](https://docs.platformio.org/en/stable/projectconf/sections/platformio/options/directory/lib_dir.html#projectconf-pio-lib-dir) (project’s private libraries and components).
+
+Although this is not the only option available for unit tests, but the recommended one.
+
+I infer that:
+
+- there actually is at least one technical difference whether the modules are put into `src` or `lib` directory
+- in case unit tests are envisioned for the modules, the recommended way is to put them into the `lib` directory
+- the `src/` directory is designated to perform dependency injection for the productive software (in contrast to the test software); compare to "Main Component" for dependency injection ([here](https://blog.cleancoder.com/uncle-bob/2021/03/06/ifElseSwitch.html) or in \cite CleanArchitecture).
+
+
+Summary
+-------
+
+Our modules (or packages) shall reside in the projects `lib_dir`: `lib/`


### PR DESCRIPTION
This decision has already been made in https://github.com/Task-Tracker-Systems/Task-Tracker-Device/pull/49#issue-1969136481. This is barely the documentation of it.