### PR TITLE
debounce buttons with a non-memorizing startup delay based on `std::thread`

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -35,3 +35,5 @@ jobs:
       run: platformio test --verbose --environment test_native_string_helpers
     - name: Run tests on the native platform for HMI layer
       run: platformio test --verbose --environment test_native_hmi
+    - name: Run tests on the native platform for Worker
+      run: platformio test --verbose --environment test_worker

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run tests on the native platform for HMI layer
       run: platformio test --verbose --environment test_native_hmi
     - name: Run tests on the native platform for Worker
-      run: platformio test --verbose --environment test_worker
+      run: platformio test --verbose --environment test_native_worker

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -32,6 +32,13 @@ static constexpr std::pair<board::PinType, KeyId> selectionForPins[] = {
     {board::button::pin::back, KeyId::BACK},
 };
 
+/**
+ * Debounce period.
+ * 
+ * Key presses must be at least this long to be detected.
+ */
+static constexpr auto debouncePeriod = 20ms;
+
 static void reactOnPinChange(const board::PinType pin, KeyId keyId)
 {
     const bool isPressed = digitalRead(pin) == LOW;
@@ -57,7 +64,7 @@ static std::thread workerManager([] {
         {
             if (!waitConditions[i].test_and_set())
             {
-                workers[i].restart(std::bind(reactOnPinChange, selectionForPins[i].first, selectionForPins[i].second), 200ms);
+                workers[i].restart(std::bind(reactOnPinChange, selectionForPins[i].first, selectionForPins[i].second), debouncePeriod);
                 std::this_thread::yield();
             }
         }

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -56,11 +56,13 @@ static std::atomic_flag waitConditions[std::size(selectionForPins)] = {ATOMIC_FL
  */
 void workerManager()
 {
-    // initialize for waiting
-    for (auto &waitCondition : waitConditions)
-    {
-        waitCondition.test_and_set();
-    }
+    static const bool initialized = [] {
+        // initialize for waiting
+        for (auto &waitCondition : waitConditions)
+        {
+            waitCondition.test_and_set();
+        } 
+        return true; }();
 
     static Worker workers[std::size(selectionForPins)];
     for (std::size_t i = 0; i < std::size(waitConditions); ++i)

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -47,21 +47,13 @@ static void reactOnPinChange()
     }
 }
 
-template <board::PinType N>
-struct WorkerPool
-{
-    static std::shared_ptr<Worker> worker;
-};
-
-template <board::PinType N>
-std::shared_ptr<Worker> WorkerPool<N>::worker;
-
 template <board::PinType PIN>
 static void isr()
 {
+    static Worker delayedStarter;
     // worker must be managed in a thread separate to the ISR to avoid deadlocks
     std::thread workerManagement([]() { Worker::restart(
-                                            WorkerPool<PIN>::worker,
+                                            delayedStarter,
                                             reactOnPinChange<PIN>,
                                             std::chrono::milliseconds(200)); });
     workerManagement.detach();

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -52,10 +52,9 @@ static void isr()
 {
     static Worker delayedStarter;
     // worker must be managed in a thread separate to the ISR to avoid deadlocks
-    std::thread workerManagement([]() { Worker::restart(
-                                            delayedStarter,
-                                            reactOnPinChange<PIN>,
-                                            std::chrono::milliseconds(200)); });
+    std::thread workerManagement([&delayedStarter]() { delayedStarter.restart(
+                                                           reactOnPinChange<PIN>,
+                                                           std::chrono::milliseconds(200)); });
     workerManagement.detach();
 }
 

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cstddef>
 #include <iterator>
+#include <memory>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -46,15 +47,24 @@ static void reactOnPinChange()
     }
 }
 
+template <board::PinType N>
+struct WorkerPool
+{
+    static std::shared_ptr<Worker> worker;
+};
+
+template <board::PinType N>
+std::shared_ptr<Worker> WorkerPool<N>::worker;
+
 template <board::PinType PIN>
 static void isr()
 {
-    using namespace std::chrono_literals;
-    constexpr auto createDebouncedCallback = []() { return Worker::spawnNew(reactOnPinChange<PIN>, 200ms); };
-    static std::shared_ptr<Worker> debouncedCallbackThread = createDebouncedCallback();
-
-    debouncedCallbackThread->cancelStartup();
-    debouncedCallbackThread = createDebouncedCallback();
+    // worker must be managed in a thread separate to the ISR to avoid deadlocks
+    std::thread workerManagement([]() { Worker::restart(
+                                            WorkerPool<PIN>::worker,
+                                            reactOnPinChange<PIN>,
+                                            std::chrono::milliseconds(200)); });
+    workerManagement.detach();
 }
 
 /**

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -52,9 +52,9 @@ static void isr()
 {
     static Worker delayedStarter;
     // worker must be managed in a thread separate to the ISR to avoid deadlocks
-    std::thread workerManagement([&delayedStarter]() { delayedStarter.restart(
-                                                           reactOnPinChange<PIN>,
-                                                           std::chrono::milliseconds(200)); });
+    std::thread workerManagement([]() { delayedStarter.restart(
+                                            reactOnPinChange<PIN>,
+                                            std::chrono::milliseconds(200)); });
     workerManagement.detach();
 }
 

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -52,11 +52,6 @@ static void isr()
     constexpr auto createDebouncedCallback = []() { return Worker(reactOnPinChange<PIN>, 200ms); };
     static Worker debouncedCallback = createDebouncedCallback();
 
-    if (debouncedCallback.isRunning())
-    {
-        debouncedCallback.cancelStartupDelay();
-        debouncedCallback.waitUntilFinished();
-    }
     debouncedCallback = createDebouncedCallback();
 }
 

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -48,7 +48,7 @@ static void reactOnPinChange()
 }
 
 template <board::PinType PIN>
-static void isr()
+static void ARDUINO_ISR_ATTR isr()
 {
     /*
      * It is not possible to have a `static Worker` (not pointer-Type) within the ISR.

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -50,10 +50,11 @@ template <board::PinType PIN>
 static void isr()
 {
     using namespace std::chrono_literals;
-    constexpr auto createDebouncedCallback = []() { return Worker(reactOnPinChange<PIN>, 200ms); };
-    static Worker debouncedCallback = createDebouncedCallback();
+    constexpr auto createDebouncedCallback = []() { return Worker::spawnNew(reactOnPinChange<PIN>, 200ms); };
+    static std::shared_ptr<Worker> debouncedCallbackThread = createDebouncedCallback();
 
-    debouncedCallback = createDebouncedCallback();
+    debouncedCallbackThread->cancelStartup();
+    debouncedCallbackThread = createDebouncedCallback();
 }
 
 /**

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -55,9 +55,13 @@ static void isr()
     {
         std::this_thread::yield(); // spin
     }
-    static Worker delayedStarter;
+    static Worker *delayedStarter = nullptr;
+    if (!delayedStarter)
+    {
+        delayedStarter = new Worker();
+    }
     // worker must be managed in a thread separate to the ISR to avoid deadlocks
-    std::thread workerManagement([]() { delayedStarter.restart(
+    std::thread workerManagement([]() { delayedStarter->restart(
                                             reactOnPinChange<PIN>,
                                             std::chrono::milliseconds(200)); });
     workerManagement.detach();

--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <board_pins.hpp>
+#include <cassert>
 #include <chrono>
 #include <cstddef>
 #include <iterator>

--- a/lib/utilities/Arduino-wrapper.h
+++ b/lib/utilities/Arduino-wrapper.h
@@ -17,9 +17,26 @@
 #endif
 
 #if defined(ArduinoFake)
+
+/* the definition in ArduinoFake is too primitive for testing */
 #if defined(digitalPinToInterrupt)
-// the definition in ArduinoFake is too primitive for testing
 #undef digitalPinToInterrupt
 #define digitalPinToInterrupt(pinNumber) pinNumber
 #endif
+
+/*
+ * Memory type attributes relevant for ESP32 must be empty defined for testing.
+ * 
+ * https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/memory-types.html#how-to-place-code-in-iram
+ */
+#if !defined(ARDUINO_ISR_ATTR)
+#define ARDUINO_ISR_ATTR
 #endif
+#if !defined(IRAM_ATTR)
+#define IRAM_ATTR
+#endif
+#if !defined(DRAM_ATTR)
+#define DRAM_ATTR
+#endif
+
+#endif /* defined(ArduinoFake) */

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -15,7 +15,7 @@ bool Worker::isRunning() const
 }
 
 Worker::Worker(std::function<void(void)> &&work)
-    : Worker(work, std::chrono::milliseconds(0))
+    : Worker(std::move(work), std::chrono::milliseconds(0))
 {
 }
 

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,5 +1,9 @@
 #include "Worker.hpp"
 
+Worker::Worker(std::function<void(void)> work)
+{
+}
+
 void Worker::wait_until_finished() const
 {
 }

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,8 +1,1 @@
 #include "Worker.hpp"
-
-void Worker::cancelStartup()
-{
-    std::unique_lock lock(abortMutex);
-    abortFlag = true;
-    abortCondition.notify_all();
-}

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,6 +1,6 @@
 #include "Worker.hpp"
 
-void Worker::wait_until_finished() const
+void Worker::waitUntilFinished() const
 {
     if (thread.joinable())
     {

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -8,5 +8,5 @@ void Worker::cancelStartup()
 
 std::shared_ptr<Worker> Worker::spawnNew(std::function<void(void)> &&work)
 {
-    return spawnNew(work, std::chrono::milliseconds(0));
+    return spawnNew(std::move(work), std::chrono::milliseconds(0));
 }

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -14,7 +14,12 @@ bool Worker::isRunning() const
     return running;
 }
 
-void Worker::cancel()
+Worker::Worker(std::function<void(void)> &&work)
+    : Worker(work, std::chrono::milliseconds(0))
+{
+}
+
+void Worker::cancelStartupDelay()
 {
     std::lock_guard lock(stateMutex);
     running = false;

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,0 +1,5 @@
+#include "Worker.hpp"
+
+void Worker::wait_until_finished() const
+{
+}

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,11 +1,5 @@
 #include "Worker.hpp"
 
-Worker::Worker(std::function<void(void)> work)
-    : running(true),
-      thread([&, work]() {work(); running=false; })
-{
-}
-
 void Worker::wait_until_finished() const
 {
     if (thread.joinable())
@@ -16,5 +10,13 @@ void Worker::wait_until_finished() const
 
 bool Worker::isRunning() const
 {
+    std::lock_guard lock(stateMutex);
     return running;
+}
+
+void Worker::cancel()
+{
+    std::lock_guard lock(stateMutex);
+    running = false;
+    stopCondition.notify_all();
 }

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,52 +1,12 @@
 #include "Worker.hpp"
 
-void Worker::joinIfJoinable()
-{
-    if (thread.joinable())
-    {
-        thread.join();
-    }
-}
-
-bool Worker::isRunning() const
-{
-    std::lock_guard lock(*stateMutex);
-    return running;
-}
-
-Worker::Worker(std::function<void(void)> &&work)
-    : Worker(std::move(work), std::chrono::milliseconds(0))
-{
-}
-
 void Worker::cancelStartup()
 {
-    std::lock_guard lock(*stateMutex);
-    running = false;
-    stopCondition->notify_all();
+    abortFlag = true;
+    abortCondition.notify_all();
 }
 
-Worker &Worker::operator=(Worker &&other)
+std::shared_ptr<Worker> Worker::spawnNew(std::function<void(void)> &&work)
 {
-    // Self-assignment check
-    if (this == &other)
-    {
-        return *this;
-    }
-
-    std::lock(*stateMutex, *(other.stateMutex));
-    std::lock_guard lock_myState(*stateMutex, std::adopt_lock);            // for RAII
-    std::lock_guard lock_otherState(*(other.stateMutex), std::adopt_lock); // for RAII
-    std::swap(running, other.running);
-    std::swap(stateMutex, other.stateMutex);
-    std::swap(stopCondition, other.stopCondition);
-    std::swap(thread, other.thread);
-
-    return *this;
-}
-
-Worker::~Worker()
-{
-    cancelStartup();
-    joinIfJoinable();
+    return spawnNew(work, std::chrono::milliseconds(0));
 }

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,9 +1,14 @@
 #include "Worker.hpp"
 
 Worker::Worker(std::function<void(void)> work)
+    : thread(work)
 {
 }
 
 void Worker::wait_until_finished() const
 {
+    if (thread.joinable())
+    {
+        thread.join();
+    }
 }

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,7 +1,8 @@
 #include "Worker.hpp"
 
 Worker::Worker(std::function<void(void)> work)
-    : thread(work)
+    : running(true),
+      thread([&, work]() {work(); running=false; })
 {
 }
 
@@ -11,4 +12,9 @@ void Worker::wait_until_finished() const
     {
         thread.join();
     }
+}
+
+bool Worker::isRunning() const
+{
+    return running;
 }

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -1,6 +1,6 @@
 #include "Worker.hpp"
 
-void Worker::waitUntilFinished() const
+void Worker::joinIfJoinable()
 {
     if (thread.joinable())
     {
@@ -10,7 +10,7 @@ void Worker::waitUntilFinished() const
 
 bool Worker::isRunning() const
 {
-    std::lock_guard lock(stateMutex);
+    std::lock_guard lock(*stateMutex);
     return running;
 }
 
@@ -19,9 +19,34 @@ Worker::Worker(std::function<void(void)> &&work)
 {
 }
 
-void Worker::cancelStartupDelay()
+void Worker::cancelStartup()
 {
-    std::lock_guard lock(stateMutex);
+    std::lock_guard lock(*stateMutex);
     running = false;
-    stopCondition.notify_all();
+    stopCondition->notify_all();
+}
+
+Worker &Worker::operator=(Worker &&other)
+{
+    // Self-assignment check
+    if (this == &other)
+    {
+        return *this;
+    }
+
+    std::lock(*stateMutex, *(other.stateMutex));
+    std::lock_guard lock_myState(*stateMutex, std::adopt_lock);            // for RAII
+    std::lock_guard lock_otherState(*(other.stateMutex), std::adopt_lock); // for RAII
+    std::swap(running, other.running);
+    std::swap(stateMutex, other.stateMutex);
+    std::swap(stopCondition, other.stopCondition);
+    std::swap(thread, other.thread);
+
+    return *this;
+}
+
+Worker::~Worker()
+{
+    cancelStartup();
+    joinIfJoinable();
 }

--- a/lib/utilities/Worker.cpp
+++ b/lib/utilities/Worker.cpp
@@ -2,11 +2,7 @@
 
 void Worker::cancelStartup()
 {
+    std::unique_lock lock(abortMutex);
     abortFlag = true;
     abortCondition.notify_all();
-}
-
-std::shared_ptr<Worker> Worker::spawnNew(std::function<void(void)> &&work)
-{
-    return spawnNew(std::move(work), std::chrono::milliseconds(0));
 }

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -10,7 +10,6 @@ class Worker
   public:
     void finish()
     {
-        std::unique_lock _(workerThreadControlMutex);
         if (delayedWorkerThread.joinable())
         {
             delayedWorkerThread.join();
@@ -19,7 +18,6 @@ class Worker
 
     void cancelStartup()
     {
-        std::unique_lock _(workerThreadControlMutex);
         if (delayedWorkerThread.joinable())
         {
             {
@@ -34,7 +32,6 @@ class Worker
     template <class Function, class Rep, class Period>
     void restart(Function &&work, const std::chrono::duration<Rep, Period> &startupDelay)
     {
-        std::unique_lock _(workerThreadControlMutex);
         cancelStartup();
 
         {
@@ -61,9 +58,8 @@ class Worker
     }
 
   private:
-    bool abortFlag;                                //!< condition for aborting the work
-    std::mutex abortMutex;                         //!< used to signal the abort condition to worker thread
-    std::recursive_mutex workerThreadControlMutex; //!< used to protect concurrent thread ending/starting
-    std::condition_variable abortSignalling;       //!< signals that it may be time to abort
-    std::thread delayedWorkerThread;               //!< performs the startup delay and work
+    bool abortFlag;                          //!< condition for aborting the work
+    std::mutex abortMutex;                   //!< used to signal the abort condition to worker thread
+    std::condition_variable abortSignalling; //!< signals that it may be time to abort
+    std::thread delayedWorkerThread;         //!< performs the startup delay and work
 };

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -24,7 +24,7 @@ class Worker
 template <class Rep, class Period>
 std::shared_ptr<Worker> Worker::spawnNew(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay)
 {
-    std::shared_ptr<Worker> worker = std::shared_ptr<Worker>(new Worker());
+    const auto worker = std::shared_ptr<Worker>(new Worker());
     std::thread workerThread(
         [](std::shared_ptr<Worker> container /* if the container goes out of scope it may call the desctructor */,
            std::function<void(void)> work,

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -1,7 +1,20 @@
 #pragma once
+#include <functional>
+#include <thread>
 
 class Worker
 {
   public:
+    template <class F, class... Args>
+    explicit Worker(F &&f, Args &&...args);
     void wait_until_finished() const;
+
+  private:
+    std::thread thread;
 };
+
+template <class F, class... Args>
+Worker::Worker(F &&f, Args &&...args)
+    : thread(f, args...)
+{
+}

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -14,6 +14,16 @@ class Worker
     static std::shared_ptr<Worker> spawnNew(std::function<void(void)> &&work);
     void cancelStartup();
 
+    template <class Rep, class Period>
+    static void restart(std::shared_ptr<Worker> &worker, std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay)
+    {
+        if (worker)
+        {
+            worker->cancelStartup();
+        }
+        worker = spawnNew(std::move(work), startupDelay);
+    }
+
   private:
     bool abortFlag;
     std::mutex abortMutex;

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -10,7 +10,7 @@ class Worker
   public:
     template <class Rep, class Period>
     Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startDelay);
-    explicit Worker(std::function<void(void)> work);
+    explicit Worker(std::function<void(void)> &&work);
     void wait_until_finished() const;
     bool isRunning() const;
     void cancelStartupDelay();
@@ -31,7 +31,6 @@ Worker::Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep
           {
               work();
           }
-          lock.lock();
           running = false;
       })
 {

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -5,16 +5,9 @@
 class Worker
 {
   public:
-    template <class F, class... Args>
-    explicit Worker(F &&f, Args &&...args);
+    explicit Worker(std::function<void(void)> work);
     void wait_until_finished() const;
 
   private:
     std::thread thread;
 };
-
-template <class F, class... Args>
-Worker::Worker(F &&f, Args &&...args)
-    : thread(f, args...)
-{
-}

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -9,9 +9,9 @@ class Worker
 {
   public:
     template <class Rep, class Period>
-    Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startDelay);
+    Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay);
     explicit Worker(std::function<void(void)> &&work);
-    void wait_until_finished() const;
+    void waitUntilFinished() const;
     bool isRunning() const;
     void cancelStartupDelay();
 
@@ -23,11 +23,11 @@ class Worker
 };
 
 template <class Rep, class Period>
-Worker::Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startDelay)
+Worker::Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay)
     : running(true),
       thread([&, work]() {
           std::unique_lock lock(stateMutex);
-          if (!stopCondition.wait_for(lock, startDelay, [&]() { return !running; }))
+          if (!stopCondition.wait_for(lock, startupDelay, [&]() { return !running; }))
           {
               work();
           }

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -30,7 +30,7 @@ std::shared_ptr<Worker> Worker::spawnNew(std::function<void(void)> &&work, const
            std::function<void(void)> work,
            const std::chrono::duration<Rep, Period> startupDelay) {
             std::unique_lock lock(container->abortMutex);
-            if (container->abortCondition.wait_for(lock, startupDelay, [&]() { return !container->abortFlag; }))
+            if (!container->abortCondition.wait_for(lock, startupDelay, [&]() { return container->abortFlag; }))
             {
                 work();
             }

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -11,23 +11,27 @@ class Worker
     template <class Rep, class Period>
     Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay);
     explicit Worker(std::function<void(void)> &&work);
-    void waitUntilFinished() const;
-    bool isRunning() const; // TODO change to "is waiting" or similar
-    void cancelStartupDelay();
+    void joinIfJoinable();
+    bool isRunning() const;
+    void cancelStartup();
+    Worker &operator=(Worker &&);
+    ~Worker();
 
   private:
     bool running;
-    mutable std::mutex stateMutex;
-    std::condition_variable stopCondition;
-    mutable std::thread thread;
+    std::unique_ptr<std::mutex> stateMutex;
+    std::unique_ptr<std::condition_variable> stopCondition;
+    std::thread thread;
 };
 
 template <class Rep, class Period>
 Worker::Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay)
     : running(true),
+      stateMutex(std::make_unique<std::mutex>()),
+      stopCondition(std::make_unique<std::condition_variable>()),
       thread([&, work]() {
-          std::unique_lock lock(stateMutex);
-          if (!stopCondition.wait_for(lock, startupDelay, [&]() { return !running; }))
+          std::unique_lock lock(*stateMutex);
+          if (!stopCondition->wait_for(lock, startupDelay, [&]() { return !running; }))
           {
               work();
           }

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include <functional>
 #include <thread>
 
@@ -7,7 +8,9 @@ class Worker
   public:
     explicit Worker(std::function<void(void)> work);
     void wait_until_finished() const;
+    bool isRunning() const;
 
   private:
+    std::atomic<bool> running;
     mutable std::thread thread;
 };

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -24,7 +24,7 @@ class Worker
 template <class Rep, class Period>
 std::shared_ptr<Worker> Worker::spawnNew(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay)
 {
-    std::shared_ptr<Worker> worker = std::make_shared<Worker>();
+    std::shared_ptr<Worker> worker = std::shared_ptr<Worker>(new Worker());
     std::thread workerThread(
         [](std::shared_ptr<Worker> container /* if the container goes out of scope it may call the desctructor */,
            std::function<void(void)> work,

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -1,16 +1,36 @@
 #pragma once
-#include <atomic>
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <thread>
 
 class Worker
 {
   public:
-    explicit Worker(std::function<void(void)> work);
+    template <class Rep, class Period>
+    explicit Worker(std::function<void(void)> work, const std::chrono::duration<Rep, Period> &startDelay = 0);
     void wait_until_finished() const;
     bool isRunning() const;
+    void cancel();
 
   private:
-    std::atomic<bool> running;
+    bool running;
+    mutable std::mutex stateMutex;
+    std::condition_variable stopCondition;
     mutable std::thread thread;
 };
+
+template <class Rep, class Period>
+Worker::Worker(std::function<void(void)> work, const std::chrono::duration<Rep, Period> &startDelay)
+    : running(true),
+      thread([&, work]() {
+          std::unique_lock lock(stateMutex);
+          if (!stopCondition.wait_for(lock, startDelay, [&]() { return !running; }))
+          {
+              work();
+          }
+          lock.lock();
+          running = false;
+      })
+{
+}

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+class Worker
+{
+  public:
+    void wait_until_finished() const;
+};

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <chrono>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
@@ -8,10 +9,11 @@ class Worker
 {
   public:
     template <class Rep, class Period>
-    explicit Worker(std::function<void(void)> work, const std::chrono::duration<Rep, Period> &startDelay = 0);
+    Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startDelay);
+    explicit Worker(std::function<void(void)> work);
     void wait_until_finished() const;
     bool isRunning() const;
-    void cancel();
+    void cancelStartupDelay();
 
   private:
     bool running;
@@ -21,7 +23,7 @@ class Worker
 };
 
 template <class Rep, class Period>
-Worker::Worker(std::function<void(void)> work, const std::chrono::duration<Rep, Period> &startDelay)
+Worker::Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startDelay)
     : running(true),
       thread([&, work]() {
           std::unique_lock lock(stateMutex);

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -12,7 +12,7 @@ class Worker
     Worker(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay);
     explicit Worker(std::function<void(void)> &&work);
     void waitUntilFinished() const;
-    bool isRunning() const;
+    bool isRunning() const; // TODO change to "is waiting" or similar
     void cancelStartupDelay();
 
   private:

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -9,5 +9,5 @@ class Worker
     void wait_until_finished() const;
 
   private:
-    std::thread thread;
+    mutable std::thread thread;
 };

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -18,7 +18,7 @@ class Worker
     bool abortFlag;
     std::mutex abortMutex;
     std::condition_variable abortCondition;
-    Worker();
+    Worker() = default;
 };
 
 template <class Rep, class Period>

--- a/lib/utilities/Worker.hpp
+++ b/lib/utilities/Worker.hpp
@@ -13,10 +13,10 @@ class Worker
     void cancelStartup();
 
     template <class Rep, class Period>
-    static void restart(Worker &worker, std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay)
+    void restart(std::function<void(void)> &&work, const std::chrono::duration<Rep, Period> &startupDelay)
     {
-        worker.cancelStartup();
-        worker.spawnNew(std::move(work), startupDelay);
+        cancelStartup();
+        spawnNew(std::move(work), startupDelay);
     }
 
   private:

--- a/lib/utilities/find.hpp
+++ b/lib/utilities/find.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <utility>
+
+template <typename T1, typename T2, std::size_t N>
+constexpr std::optional<T2> find_second_for_first(const std::pair<T1, T2> (&arr)[N], const T1 &first_value)
+{
+    for (const auto &pair : arr)
+    {
+        if (pair.first == first_value)
+        {
+            return pair.second;
+        }
+    }
+    return std::nullopt;
+}
+
+template <typename T1, typename T2, std::size_t N>
+constexpr std::optional<std::size_t> find_index_for_first(const std::pair<T1, T2> (&arr)[N], const T1 &first_value)
+{
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        if (arr[i].first == first_value)
+        {
+            return i;
+        }
+    }
+    return std::nullopt;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,3 +101,8 @@ lib_deps =
 	${test_native.lib_deps}
 	application_business_rules
 	board_adapters
+
+[env:test_native_worker]
+extends = test_native
+test_filter = test_worker
+debug_test = test_worker

--- a/test/test_hmi/test_hmi.cpp
+++ b/test/test_hmi/test_hmi.cpp
@@ -89,6 +89,7 @@ void test_Controller()
     const auto isrTask1 = isr_collection.find(board::button::pin::task1); // ISR we expect for task 1
     TEST_ASSERT_NOT_EQUAL(std::end(isr_collection), isrTask1);            // assert we found an ISR for task 1 in the list
 
+    std::cout << "trigger ISR for task 1: 'start task'" << std::endl;
     When(Method(ArduinoFake(), digitalRead).Using(board::button::pin::task1)).Return(LOW); // set task 1 button to low
     isrTask1->second();                                                                    // trigger interrupt for task 1 button
 
@@ -102,6 +103,7 @@ void test_Controller()
     constexpr int millisecondsToWait = 1000;
     std::this_thread::sleep_for(std::chrono::milliseconds(millisecondsToWait)); // wait a defined time
 
+    std::cout << "trigger ISR for task 1: 'stop task'" << std::endl;
     When(Method(ArduinoFake(), digitalRead).Using(board::button::pin::task1)).Return(LOW); // set task 1 button to low
     isrTask1->second();                                                                    // stop task
 

--- a/test/test_hmi/test_hmi.cpp
+++ b/test/test_hmi/test_hmi.cpp
@@ -49,48 +49,54 @@ void tearDown()
 
 void test_Controller()
 {
-    struct IsrHandle
-    {
-        board::PinType associatedPin;
-        void (*isrFunction)(void);
-    };
-
-    std::map<board::PinType, void (*)(void)> isr_collection;
-
+    // irrelevant test doubles
     Fake(Method(ArduinoFake(), pinMode));
     Fake(Method(ArduinoFake(), analogWrite));
     Fake(Method(ArduinoFake(), tone));
-    When(Method(ArduinoFake(), attachInterrupt)).AlwaysDo([&isr_collection](const auto interruptNum, const auto userFunc, const auto mode) {
+
+    // Faking attaching ISRs
+    std::map<int, void (*)(void)> isr_collection;
+    When(Method(ArduinoFake(), attachInterrupt)).AlwaysDo([&isr_collection](const int interruptNum, void (*const userFunc)(void), [[maybe_unused]] const auto mode) {
         isr_collection.emplace(interruptNum, userFunc);
-        std::cout << "Added ISR for interrupt number " << static_cast<unsigned int>(interruptNum)
-                  << " function pointer " << std::showbase << std::hex << reinterpret_cast<std::intptr_t>(userFunc) << std::resetiosflags(std::ios::showbase | std::ios::basefield) << std::endl;
+        std::cout << "Added ISR for interrupt number: " << interruptNum
+                  << " mode: " << mode
+                  << " and function pointer: " << std::showbase << std::hex << reinterpret_cast<std::intptr_t>(userFunc) << std::resetiosflags(std::ios::showbase | std::ios::basefield) << std::endl;
     });
 
+    // get collaborator objects
     Menu singleMenu(board::getDisplay());
     Presenter presenter(singleMenu, board::getStatusIndicators());
     ProcessHmiInputs processor(presenter, board::getKeypad());
+    auto &task1 = std::begin(device::tasks)->second;                      // we are going to test for task 1
+    const auto isrTask1 = isr_collection.find(board::button::pin::task1); // ISR we expect for task 1
+    TEST_ASSERT_NOT_EQUAL(std::end(isr_collection), isrTask1);            // assert we found an ISR for task 1 in the list
 
-    auto &task1 = std::begin(device::tasks)->second;
-    const auto isrTask1 = isr_collection.find(board::button::pin::task1);
-    TEST_ASSERT_NOT_EQUAL(std::end(isr_collection), isrTask1);
-    When(Method(ArduinoFake(), millis)).Return(700); // assume the processor is already running for some time
-    isrTask1->second();                              // start task
+    When(Method(ArduinoFake(), digitalRead).Using(board::button::pin::task1)).Return(LOW); // set task 1 button to low
+    isrTask1->second();                                                                    // trigger interrupt for task 1 button
+
+    // wait for the task to be running
     while (!task1.isRunning())
     {
         // TODO it would be better to explicitly check for the "stop" task to be finished
         std::this_thread::yield(); // give the task handler time to finish before the test interferes
     }
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(1000ms);
-    When(Method(ArduinoFake(), millis)).Return(700 + 1337); // used in ISR for debouncing
-    isrTask1->second();                                     // stop task
+
+    constexpr int millisecondsToWait = 1000;
+    std::this_thread::sleep_for(std::chrono::milliseconds(millisecondsToWait)); // wait a defined time
+
+    When(Method(ArduinoFake(), digitalRead).Using(board::button::pin::task1)).Return(LOW); // set task 1 button to low
+    isrTask1->second();                                                                    // stop task
+
+    // wait for the task to be stopped
     while (task1.isRunning())
     {
         // TODO it would be better to explicitly check for the "start" task to be finished
         std::this_thread::yield(); // give the task handler time to finish before the test interferes
     }
-    const auto measured = std::chrono::duration_cast<std::chrono::milliseconds>(task1.getRecordedDuration());
-    TEST_ASSERT_INT_WITHIN(10, 1000, measured.count());
+
+    // assert results
+    const auto millisecondsMeasured = std::chrono::duration_cast<std::chrono::milliseconds>(task1.getRecordedDuration());
+    TEST_ASSERT_INT_WITHIN(10, millisecondsToWait, millisecondsMeasured.count());
 }
 
 int main(int argc, char **argv)

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -73,21 +73,6 @@ void test_continuous_abort()
     TEST_ASSERT_TRUE(workCompleted);
 }
 
-void test_restart_burst()
-{
-    Worker worker;
-
-    std::vector<std::thread> threads;
-    for (auto numberOfThreadsToCreate = 10; numberOfThreadsToCreate > 0; --numberOfThreadsToCreate)
-    {
-        threads.emplace_back([&] { worker.restart(work, T_eps); });
-    }
-    std::for_each(std::begin(threads), std::end(threads), std::mem_fn(&std::thread::join));
-
-    worker.finish();
-    TEST_ASSERT_TRUE(workCompleted);
-}
-
 int main()
 {
     UNITY_BEGIN();
@@ -97,6 +82,5 @@ int main()
     RUN_TEST(test_abort);
     RUN_TEST(test_abort_and_run);
     RUN_TEST(test_continuous_abort);
-    RUN_TEST(test_restart_burst);
     return UNITY_END();
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -1,0 +1,15 @@
+#include <unity.h>
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+int main()
+{
+    UNITY_BEGIN();
+    return UNITY_END();
+}

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -21,7 +21,7 @@ void test_run_worker()
         flag = true;
     };
     Worker w(work);
-    w.wait_until_finished();
+    w.waitUntilFinished();
     TEST_ASSERT_TRUE(flag);
 }
 
@@ -32,7 +32,7 @@ void test_check_if_running()
     };
     Worker w(work);
     TEST_ASSERT_TRUE(w.isRunning());
-    w.wait_until_finished();
+    w.waitUntilFinished();
     TEST_ASSERT_FALSE(w.isRunning());
 }
 
@@ -43,7 +43,7 @@ void test_abort()
     Worker w(work, 1s);
     TEST_ASSERT_TRUE(w.isRunning());
     w.cancelStartupDelay();
-    w.wait_until_finished();
+    w.waitUntilFinished();
     TEST_ASSERT_FALSE(w.isRunning());
     TEST_ASSERT_FALSE(flag);
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -76,16 +76,20 @@ void test_continuous_abort()
 void test_restart_burst()
 {
     Worker worker;
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
-    worker.restart(work, T_eps);
+    auto furtherRestarts = 10;
+    auto concurrentRestart = [&worker](const auto &self, const auto more) {
+        std::thread t(&Worker::restart, &worker, work, T_eps);
+        if (more > 0)
+        {
+            self(self, more - 1);
+        }
+        t.join();
+    };
+
+    auto recursionHelper = [&concurrentRestart](const auto furtherRestarts) {
+        concurrentRestart(concurrentRestart, furtherRestarts);
+    };
+
     worker.finish();
     TEST_ASSERT_TRUE(workCompleted);
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -1,4 +1,5 @@
 #include <Worker.hpp>
+#include <atomic>
 #include <chrono>
 #include <unity.h>
 
@@ -35,10 +36,23 @@ void test_check_if_running()
     TEST_ASSERT_FALSE(w.isRunning());
 }
 
+void test_abort()
+{
+    std::atomic<bool> flag = false;
+    const auto work = [&]() { flag = true; };
+    Worker w(work, 1s);
+    TEST_ASSERT_TRUE(w.isRunning());
+    w.cancel();
+    w.wait_until_finished();
+    TEST_ASSERT_FALSE(w.isRunning());
+    TEST_ASSERT_FALSE(flag);
+}
+
 int main()
 {
     UNITY_BEGIN();
     RUN_TEST(test_run_worker);
     RUN_TEST(test_check_if_running);
+    RUN_TEST(test_abort);
     return UNITY_END();
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -1,3 +1,4 @@
+#include <Worker.hpp>
 #include <unity.h>
 
 void setUp(void)
@@ -6,6 +7,12 @@ void setUp(void)
 
 void tearDown(void)
 {
+}
+
+void test_run_worker()
+{
+    Worker w;
+    w.wait_until_finished();
 }
 
 int main()

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -76,21 +76,13 @@ void test_continuous_abort()
 void test_restart_burst()
 {
     Worker worker;
-    auto furtherRestarts = 10;
-    auto concurrentRestart = [&worker](const auto &self, const auto more) -> void {
-        std::thread t([&] { worker.restart(work, T_eps); });
-        if (more > 0)
-        {
-            self(self, more - 1);
-        }
-        t.join();
-    };
 
-    auto recursionHelper = [&concurrentRestart](const auto furtherRestarts) -> void {
-        concurrentRestart(concurrentRestart, furtherRestarts);
-    };
-
-    recursionHelper(furtherRestarts);
+    std::vector<std::thread> threads;
+    for (auto numberOfThreadsToCreate = 10; numberOfThreadsToCreate > 0; --numberOfThreadsToCreate)
+    {
+        threads.emplace_back([&] { worker.restart(work, T_eps); });
+    }
+    std::for_each(std::begin(threads), std::end(threads), std::mem_fn(&std::thread::join));
 
     worker.finish();
     TEST_ASSERT_TRUE(workCompleted);

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -11,8 +11,11 @@ void tearDown(void)
 
 void test_run_worker()
 {
-    Worker w;
+    bool flag = false;
+    const auto work = [&flag]() { flag = true; };
+    Worker w(work);
     w.wait_until_finished();
+    TEST_ASSERT_TRUE(flag);
 }
 
 int main()

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -73,6 +73,23 @@ void test_continuous_abort()
     TEST_ASSERT_TRUE(workCompleted);
 }
 
+void test_restart_burst()
+{
+    Worker worker;
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.restart(work, T_eps);
+    worker.finish();
+    TEST_ASSERT_TRUE(workCompleted);
+}
+
 int main()
 {
     UNITY_BEGIN();
@@ -82,6 +99,6 @@ int main()
     RUN_TEST(test_abort);
     RUN_TEST(test_abort_and_run);
     RUN_TEST(test_continuous_abort);
-    RUN_TEST(test_abort);
+    RUN_TEST(test_restart_burst);
     return UNITY_END();
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -77,8 +77,8 @@ void test_restart_burst()
 {
     Worker worker;
     auto furtherRestarts = 10;
-    auto concurrentRestart = [&worker](const auto &self, const auto more) {
-        std::thread t(&Worker::restart, &worker, work, T_eps);
+    auto concurrentRestart = [&worker](const auto &self, const auto more) -> void {
+        std::thread t([&] { worker.restart(work, T_eps); });
         if (more > 0)
         {
             self(self, more - 1);
@@ -86,9 +86,11 @@ void test_restart_burst()
         t.join();
     };
 
-    auto recursionHelper = [&concurrentRestart](const auto furtherRestarts) {
+    auto recursionHelper = [&concurrentRestart](const auto furtherRestarts) -> void {
         concurrentRestart(concurrentRestart, furtherRestarts);
     };
+
+    recursionHelper(furtherRestarts);
 
     worker.finish();
     TEST_ASSERT_TRUE(workCompleted);

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -13,13 +13,19 @@ void tearDown(void)
 {
 }
 
+/**
+ * - when to pass the arguments to the methods of Worker as T, T& or T&&?
+ * - worker must have static storage duration?
+ * 
+ */
+
+Worker worker;
 void test_run_worker()
 {
     std::atomic<bool> flag = false;
     const auto work = [&flag]() {
         flag = true;
     };
-    Worker worker;
     worker.spawnNew(work, 0ms);
     std::this_thread::sleep_for(15ms);
     TEST_ASSERT_TRUE(flag);
@@ -69,6 +75,7 @@ void test_abort2()
 int main()
 {
     UNITY_BEGIN();
+    RUN_TEST(test_run_worker);
     RUN_TEST(test_run_worker);
     RUN_TEST(test_run_worker2);
     RUN_TEST(test_abort);

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -24,6 +24,18 @@ void test_run_worker()
     TEST_ASSERT_TRUE(flag);
 }
 
+void test_run_worker2()
+{
+    std::atomic<bool> flag = false;
+    const auto work = [&flag]() {
+        flag = true;
+    };
+    std::shared_ptr<Worker> worker;
+    Worker::restart(worker, work, 10ms);
+    std::this_thread::sleep_for(20ms);
+    TEST_ASSERT_TRUE(flag);
+}
+
 void test_abort()
 {
     std::atomic<bool> flag = false;
@@ -33,6 +45,23 @@ void test_abort()
     const auto worker = Worker::spawnNew(work, 100ms);
     std::this_thread::sleep_for(20ms);
     worker->cancelStartup();
+    std::this_thread::sleep_for(100ms);
+    TEST_ASSERT_FALSE(flag);
+}
+
+void test_abort2()
+{
+    std::atomic<bool> flag = false;
+    const auto work = [&flag]() {
+        flag = true;
+    };
+
+    std::shared_ptr<Worker> worker;
+    Worker::restart(worker, work, 100ms);
+    std::this_thread::sleep_for(20ms);
+    Worker::restart(
+        worker, []() {}, 20ms);
+    std::this_thread::sleep_for(140ms);
     TEST_ASSERT_FALSE(flag);
 }
 
@@ -40,6 +69,8 @@ int main()
 {
     UNITY_BEGIN();
     RUN_TEST(test_run_worker);
+    RUN_TEST(test_run_worker2);
     RUN_TEST(test_abort);
+    RUN_TEST(test_abort2);
     return UNITY_END();
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -15,36 +15,24 @@ void tearDown(void)
 
 void test_run_worker()
 {
-    bool flag = false;
+    std::atomic<bool> flag = false;
     const auto work = [&flag]() {
-        std::this_thread::sleep_for(1s);
         flag = true;
     };
-    Worker w(work);
-    w.joinIfJoinable();
+    const auto worker = Worker::spawnNew(work);
+    std::this_thread::sleep_for(15ms);
     TEST_ASSERT_TRUE(flag);
-}
-
-void test_check_if_running()
-{
-    const auto work = []() {
-        std::this_thread::sleep_for(1s);
-    };
-    Worker w(work);
-    TEST_ASSERT_TRUE(w.isRunning());
-    w.joinIfJoinable();
-    TEST_ASSERT_FALSE(w.isRunning());
 }
 
 void test_abort()
 {
     std::atomic<bool> flag = false;
-    const auto work = [&]() { flag = true; };
-    Worker w(work, 1s);
-    TEST_ASSERT_TRUE(w.isRunning());
-    w.cancelStartup();
-    w.joinIfJoinable();
-    TEST_ASSERT_FALSE(w.isRunning());
+    const auto work = [&flag]() {
+        flag = true;
+    };
+    const auto worker = Worker::spawnNew(work, 100ms);
+    std::this_thread::sleep_for(20ms);
+    worker->cancelStartup();
     TEST_ASSERT_FALSE(flag);
 }
 
@@ -52,7 +40,6 @@ int main()
 {
     UNITY_BEGIN();
     RUN_TEST(test_run_worker);
-    RUN_TEST(test_check_if_running);
     RUN_TEST(test_abort);
     return UNITY_END();
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -32,7 +32,7 @@ void test_run_worker2()
         flag = true;
     };
     Worker worker;
-    worker.restart(worker, work, 10ms);
+    worker.restart(work, 10ms);
     std::this_thread::sleep_for(20ms);
     TEST_ASSERT_TRUE(flag);
 }
@@ -59,10 +59,9 @@ void test_abort2()
     };
 
     Worker worker;
-    worker.restart(worker, work, 100ms);
+    worker.restart(work, 100ms);
     std::this_thread::sleep_for(20ms);
-    worker.restart(
-        worker, []() {}, 20ms);
+    worker.restart([]() {}, 20ms);
     std::this_thread::sleep_for(140ms);
     TEST_ASSERT_FALSE(flag);
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -1,5 +1,8 @@
 #include <Worker.hpp>
+#include <chrono>
 #include <unity.h>
+
+using namespace std::chrono_literals;
 
 void setUp(void)
 {
@@ -12,7 +15,10 @@ void tearDown(void)
 void test_run_worker()
 {
     bool flag = false;
-    const auto work = [&flag]() { flag = true; };
+    const auto work = [&flag]() {
+        std::this_thread::sleep_for(1s);
+        flag = true;
+    };
     Worker w(work);
     w.wait_until_finished();
     TEST_ASSERT_TRUE(flag);
@@ -21,5 +27,6 @@ void test_run_worker()
 int main()
 {
     UNITY_BEGIN();
+    RUN_TEST(test_run_worker);
     return UNITY_END();
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -21,7 +21,7 @@ void test_run_worker()
         flag = true;
     };
     Worker w(work);
-    w.waitUntilFinished();
+    w.joinIfJoinable();
     TEST_ASSERT_TRUE(flag);
 }
 
@@ -32,7 +32,7 @@ void test_check_if_running()
     };
     Worker w(work);
     TEST_ASSERT_TRUE(w.isRunning());
-    w.waitUntilFinished();
+    w.joinIfJoinable();
     TEST_ASSERT_FALSE(w.isRunning());
 }
 
@@ -42,8 +42,8 @@ void test_abort()
     const auto work = [&]() { flag = true; };
     Worker w(work, 1s);
     TEST_ASSERT_TRUE(w.isRunning());
-    w.cancelStartupDelay();
-    w.waitUntilFinished();
+    w.cancelStartup();
+    w.joinIfJoinable();
     TEST_ASSERT_FALSE(w.isRunning());
     TEST_ASSERT_FALSE(flag);
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -5,80 +5,83 @@
 
 using namespace std::chrono_literals;
 
+static std::atomic<bool> workCompleted = false;
+static constexpr auto work = []() {
+    workCompleted = true;
+};
+
+static constexpr auto T_eps = 10ms;
+
 void setUp(void)
 {
+    workCompleted = false;
 }
 
 void tearDown(void)
 {
 }
 
-/**
- * - when to pass the arguments to the methods of Worker as T, T& or T&&?
- * - worker must have static storage duration?
- * 
- */
-
-Worker worker;
-void test_run_worker()
+void test_do_work_once()
 {
-    std::atomic<bool> flag = false;
-    const auto work = [&flag]() {
-        flag = true;
-    };
-    worker.spawnNew(work, 0ms);
-    std::this_thread::sleep_for(15ms);
-    TEST_ASSERT_TRUE(flag);
+    Worker worker;
+    worker.restart(work, 0ms);
+    worker.finish();
+    TEST_ASSERT_TRUE(workCompleted);
 }
 
-void test_run_worker2()
+void test_do_work_once_after_delay()
 {
-    std::atomic<bool> flag = false;
-    const auto work = [&flag]() {
-        flag = true;
-    };
     Worker worker;
-    worker.restart(work, 10ms);
-    std::this_thread::sleep_for(20ms);
-    TEST_ASSERT_TRUE(flag);
+    worker.restart(work, 2 * T_eps);
+    std::this_thread::sleep_for(T_eps);
+    TEST_ASSERT_FALSE(workCompleted);
+    std::this_thread::sleep_for(2 * T_eps);
+    TEST_ASSERT_TRUE(workCompleted);
 }
 
 void test_abort()
 {
-    std::atomic<bool> flag = false;
-    const auto work = [&flag]() {
-        flag = true;
-    };
     Worker worker;
-    worker.spawnNew(work, 100ms);
-    std::this_thread::sleep_for(20ms);
+    worker.restart(work, T_eps);
     worker.cancelStartup();
-    std::this_thread::sleep_for(100ms);
-    TEST_ASSERT_FALSE(flag);
+    TEST_ASSERT_FALSE(workCompleted);
 }
 
-void test_abort2()
+void test_abort_and_run()
 {
-    std::atomic<bool> flag = false;
-    const auto work = [&flag]() {
-        flag = true;
-    };
-
     Worker worker;
-    worker.restart(work, 100ms);
-    std::this_thread::sleep_for(20ms);
-    worker.restart([]() {}, 20ms);
-    std::this_thread::sleep_for(140ms);
-    TEST_ASSERT_FALSE(flag);
+    worker.restart(work, 2 * T_eps);
+    std::this_thread::sleep_for(T_eps);
+    worker.restart(work, 3 * T_eps);
+    std::this_thread::sleep_for(2 * T_eps);
+    TEST_ASSERT_FALSE(workCompleted);
+    std::this_thread::sleep_for(2 * T_eps);
+    TEST_ASSERT_TRUE(workCompleted);
+}
+
+void test_continuous_abort()
+{
+    Worker worker;
+    for (auto i = 10; i > 0; --i)
+    {
+        worker.restart(work, 2 * T_eps);
+        std::this_thread::sleep_for(T_eps);
+        TEST_ASSERT_FALSE(workCompleted);
+    }
+
+    std::this_thread::sleep_for(2 * T_eps);
+    TEST_ASSERT_TRUE(workCompleted);
 }
 
 int main()
 {
     UNITY_BEGIN();
-    RUN_TEST(test_run_worker);
-    RUN_TEST(test_run_worker);
-    RUN_TEST(test_run_worker2);
+    RUN_TEST(test_do_work_once);
+    RUN_TEST(test_do_work_once);
+    RUN_TEST(test_do_work_once_after_delay);
     RUN_TEST(test_abort);
-    RUN_TEST(test_abort2);
+    RUN_TEST(test_abort_and_run);
+    RUN_TEST(test_continuous_abort);
+    RUN_TEST(test_abort);
     return UNITY_END();
 }

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -42,7 +42,7 @@ void test_abort()
     const auto work = [&]() { flag = true; };
     Worker w(work, 1s);
     TEST_ASSERT_TRUE(w.isRunning());
-    w.cancel();
+    w.cancelStartupDelay();
     w.wait_until_finished();
     TEST_ASSERT_FALSE(w.isRunning());
     TEST_ASSERT_FALSE(flag);

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -19,7 +19,8 @@ void test_run_worker()
     const auto work = [&flag]() {
         flag = true;
     };
-    const auto worker = Worker::spawnNew(work);
+    Worker worker;
+    worker.spawnNew(work, 0ms);
     std::this_thread::sleep_for(15ms);
     TEST_ASSERT_TRUE(flag);
 }
@@ -30,8 +31,8 @@ void test_run_worker2()
     const auto work = [&flag]() {
         flag = true;
     };
-    std::shared_ptr<Worker> worker;
-    Worker::restart(worker, work, 10ms);
+    Worker worker;
+    worker.restart(worker, work, 10ms);
     std::this_thread::sleep_for(20ms);
     TEST_ASSERT_TRUE(flag);
 }
@@ -42,9 +43,10 @@ void test_abort()
     const auto work = [&flag]() {
         flag = true;
     };
-    const auto worker = Worker::spawnNew(work, 100ms);
+    Worker worker;
+    worker.spawnNew(work, 100ms);
     std::this_thread::sleep_for(20ms);
-    worker->cancelStartup();
+    worker.cancelStartup();
     std::this_thread::sleep_for(100ms);
     TEST_ASSERT_FALSE(flag);
 }
@@ -56,10 +58,10 @@ void test_abort2()
         flag = true;
     };
 
-    std::shared_ptr<Worker> worker;
-    Worker::restart(worker, work, 100ms);
+    Worker worker;
+    worker.restart(worker, work, 100ms);
     std::this_thread::sleep_for(20ms);
-    Worker::restart(
+    worker.restart(
         worker, []() {}, 20ms);
     std::this_thread::sleep_for(140ms);
     TEST_ASSERT_FALSE(flag);

--- a/test/test_worker/test_worker.cpp
+++ b/test/test_worker/test_worker.cpp
@@ -24,9 +24,21 @@ void test_run_worker()
     TEST_ASSERT_TRUE(flag);
 }
 
+void test_check_if_running()
+{
+    const auto work = []() {
+        std::this_thread::sleep_for(1s);
+    };
+    Worker w(work);
+    TEST_ASSERT_TRUE(w.isRunning());
+    w.wait_until_finished();
+    TEST_ASSERT_FALSE(w.isRunning());
+}
+
 int main()
 {
     UNITY_BEGIN();
     RUN_TEST(test_run_worker);
+    RUN_TEST(test_check_if_running);
     return UNITY_END();
 }


### PR DESCRIPTION
Introduce a new `Worker` class which is a wrapper around a `std::thread` and:

- allows for a delayed start of the actual work
- allows to abort while still in the start delay
- provides a getter to see if the thread is finished (without the need to `join()`



Resolves #113.