### PR TITLE
Place ISR to instruction-RAM

### DIFF
--- a/lib/board_adapters/input_device_interface/Keypad.cpp
+++ b/lib/board_adapters/input_device_interface/Keypad.cpp
@@ -10,7 +10,7 @@
 static HmiHandler callBack;
 
 template <KeyId SELECTION>
-static void isr()
+static void ARDUINO_ISR_ATTR isr()
 {
     static std::thread *p_callbackThread = nullptr;
     const auto now = millis(); /* warning: `now()` from <chrono>/libc can not be used in ISRs */

--- a/lib/utilities/Arduino-wrapper.h
+++ b/lib/utilities/Arduino-wrapper.h
@@ -17,9 +17,26 @@
 #endif
 
 #if defined(ArduinoFake)
+
+/* the definition in ArduinoFake is too primitive for testing */
 #if defined(digitalPinToInterrupt)
-// the definition in ArduinoFake is too primitive for testing
 #undef digitalPinToInterrupt
 #define digitalPinToInterrupt(pinNumber) pinNumber
 #endif
+
+/*
+ * Memory type attributes relevant for ESP32 must be empty defined for testing.
+ * 
+ * https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/memory-types.html#how-to-place-code-in-iram
+ */
+#if !defined(ARDUINO_ISR_ATTR)
+#define ARDUINO_ISR_ATTR
 #endif
+#if !defined(IRAM_ATTR)
+#define IRAM_ATTR
+#endif
+#if !defined(DRAM_ATTR)
+#define DRAM_ATTR
+#endif
+
+#endif /* defined(ArduinoFake) */


### PR DESCRIPTION
This should [make the call to the ISR safer](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/spi_flash/spi_flash_concurrency.html#iram-safe-interrupt-handlers).

Using indirection via ARDUINO_ISR_ATTR in order to respect configuration.