### PR TITLE
Reduce amount of logging messages printed by LVGL.

### DIFF
--- a/lib/3rd_party_adapters/LVGL/GuiEngine.cpp
+++ b/lib/3rd_party_adapters/LVGL/GuiEngine.cpp
@@ -201,9 +201,9 @@ void GuiEngine::registerKeyPad(IKeypad *keypad)
 void GuiEngine::refresh()
 {
     lv_timer_handler();
-    LV_LOG_USER("Adafruit display() start");
+    LV_LOG_TRACE("Adafruit display() start");
     this->display.display();
-    LV_LOG_USER("Adafruit display() end");
+    LV_LOG_TRACE("Adafruit display() end");
 }
 
 /**

--- a/lib/3rd_party_adapters/LVGL/lv_conf.h
+++ b/lib/3rd_party_adapters/LVGL/lv_conf.h
@@ -240,7 +240,7 @@
     *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
     *LV_LOG_LEVEL_USER        Only logs added by the user
     *LV_LOG_LEVEL_NONE        Do not log anything*/
-    #define LV_LOG_LEVEL LV_LOG_LEVEL_INFO
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
 
     /*1: Print the log with 'printf';
     *0: User need to register a callback with `lv_log_register_print_cb()`*/


### PR DESCRIPTION
I guess the logging level was set low for debugging. In the "productive" version this is not necessary. Instead reduce clutter from regular serial interface communication.