### PR TITLE
update clang format dependency

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Run clang-format style check.
       uses: jidicula/clang-format-action@v4.11.0
       with:
-        clang-format-version: '17'
+        clang-format-version: '18'
         fallback-style: 'none'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,9 @@ Please document your code in Doxygen compatible syntax.
 Please format your changes using [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html).
 A style configuration file is given: [`.clang-format`](.clang-format)
 
+Unfortunately the output also depends on the clang-format version.
+The reference version to be used is the one used by the verification scripts ("CI/CD pipeline").
+
 Although the standalone tool `clang-format` may be used, we recommend to integrate the formatting using a [plugin](https://firefox-source-docs.mozilla.org/code-quality/coding-style/format_cpp_code_with_clang-format.html#editor-plugins) for the editor of your choice.
 
 #### Naming convention


### PR DESCRIPTION
- update pipeline to use clang-format v18 in order to avoid compatibility problems with newer versions
- add a note to the documentation that the ClangFormat version is relevant